### PR TITLE
0.6.5: deprecate :adapter_error default retry without escalation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.6.5 (2026-04-21)
+
+### Deprecated
+
+- **`:adapter_error` in `DEFAULT_RETRY_ON` is deprecated** and will be removed from the default in 0.7.0. A runtime deprecation warning is emitted when a step uses the default retry set with `attempts > 1` and no model escalation chain. `ruby_llm` already retries transport errors (`RateLimitError`, `ServerError`, `ServiceUnavailableError`, `OverloadedError`, timeouts) at the Faraday layer, so retrying on `:adapter_error` without escalation re-runs the same model on errors the HTTP middleware already retried with backoff. To silence the warning:
+  - **Keep current behavior:** `retry_on :validation_failed, :parse_error, :adapter_error`
+  - **Adopt the future default:** `retry_on :validation_failed, :parse_error`
+  - **Use `:adapter_error` meaningfully:** pair it with `escalate "model_a", "model_b"` so a different model/provider gets a chance after transport errors that Faraday could not resolve.
+
 ## 0.6.4 (2026-04-20)
 
 ### Features

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby_llm-contract (0.6.4)
+    ruby_llm-contract (0.6.5)
       dry-types (~> 1.7)
       ruby_llm (~> 1.0)
       ruby_llm-schema (~> 0.3)
@@ -258,7 +258,7 @@ CHECKSUMS
   rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   ruby_llm (1.14.0) sha256=57c6f7034fc4a44504ea137d70f853b07824f1c1cdbe774ab3ab3522e7098deb
-  ruby_llm-contract (0.6.4)
+  ruby_llm-contract (0.6.5)
   ruby_llm-schema (0.3.0) sha256=a591edc5ca1b7f0304f0e2261de61ba4b3bea17be09f5cf7558153adfda3dec6
   ruby_parser (3.22.0) sha256=1eb4937cd9eb220aa2d194e352a24dba90aef00751e24c8dfffdb14000f15d23
   rubycritic (4.12.0) sha256=024fed90fe656fa939f6ea80aab17569699ac3863d0b52fd72cb99892247abc8

--- a/lib/ruby_llm/contract/step/retry_policy.rb
+++ b/lib/ruby_llm/contract/step/retry_policy.rb
@@ -8,9 +8,38 @@ module RubyLLM
 
         DEFAULT_RETRY_ON = %i[validation_failed parse_error adapter_error].freeze
 
+        ADAPTER_ERROR_DEPRECATION_MESSAGE = "#{<<~MSG.tr("\n", " ").strip}\n".freeze
+          [ruby_llm-contract] DEPRECATION: :adapter_error will be removed from
+          DEFAULT_RETRY_ON in 0.7.0. Without a model escalation chain this retries
+          the same model on transport errors that ruby_llm's Faraday middleware
+          already retried with backoff.
+          Keep current behavior: `retry_on :validation_failed, :parse_error, :adapter_error`.
+          Adopt new default: `retry_on :validation_failed, :parse_error`.
+          Use :adapter_error with `escalate "model_a", "model_b"` for meaningful fallback.
+        MSG
+
+        @adapter_error_default_warned = false
+        @deprecation_mutex = Mutex.new
+
+        class << self
+          # Emitted once per process to avoid stderr noise from inherited Step
+          # classes, Rails reload cycles, or CI configurations that fail on
+          # stderr. Tests may reset this flag via #reset_deprecation_warnings!.
+          # Thread-safety: check-then-set is guarded by @deprecation_mutex so
+          # concurrent RetryPolicy.new calls (e.g. production_mode eval
+          # candidates) cannot race past the flag.
+          attr_accessor :adapter_error_default_warned
+          attr_reader :deprecation_mutex
+
+          def reset_deprecation_warnings!
+            @deprecation_mutex.synchronize { @adapter_error_default_warned = false }
+          end
+        end
+
         def initialize(models: nil, attempts: nil, retry_on: nil, &block)
           @configs = []
           @retryable_statuses = DEFAULT_RETRY_ON.dup
+          @retry_on_explicit = false
 
           if block
             @max_attempts = 1
@@ -21,6 +50,7 @@ module RubyLLM
           end
 
           validate_max_attempts!
+          warn_adapter_error_default_deprecated!
         end
 
         def attempts(count)
@@ -44,6 +74,7 @@ module RubyLLM
 
         def retry_on(*statuses)
           @retryable_statuses = statuses.flatten
+          @retry_on_explicit = true
         end
 
         def retryable?(result)
@@ -71,7 +102,10 @@ module RubyLLM
           else
             @max_attempts = attempts || 1
           end
-          @retryable_statuses = Array(retry_on).dup if retry_on
+          return unless retry_on
+
+          @retryable_statuses = Array(retry_on).dup
+          @retry_on_explicit = true
         end
 
         def normalize_config(entry)
@@ -82,6 +116,26 @@ module RubyLLM
           warn "[ruby_llm-contract] retry_policy has max_attempts=1 with no configs. " \
                "This means no actual retry will happen. Add `attempts 2` or " \
                '`escalate "model1", "model2"`.'
+        end
+
+        def warn_adapter_error_default_deprecated!
+          return unless should_warn_adapter_error_default?
+          return if self.class.adapter_error_default_warned
+
+          self.class.deprecation_mutex.synchronize do
+            return if self.class.adapter_error_default_warned
+
+            self.class.adapter_error_default_warned = true
+            Warning.warn(ADAPTER_ERROR_DEPRECATION_MESSAGE)
+          end
+        end
+
+        def should_warn_adapter_error_default?
+          return false if @retry_on_explicit
+          return false if @max_attempts <= 1
+          return false if @configs.size >= 2
+
+          @retryable_statuses.include?(:adapter_error)
         end
 
         def validate_max_attempts!

--- a/lib/ruby_llm/contract/version.rb
+++ b/lib/ruby_llm/contract/version.rb
@@ -2,6 +2,6 @@
 
 module RubyLLM
   module Contract
-    VERSION = "0.6.4"
+    VERSION = "0.6.5"
   end
 end

--- a/spec/ruby_llm/contract/step/retry_policy_spec.rb
+++ b/spec/ruby_llm/contract/step/retry_policy_spec.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "stringio"
+require "timeout"
+
 RSpec.describe RubyLLM::Contract::Step::RetryPolicy do
   describe "configuration" do
     it "defaults to 1 attempt" do
@@ -38,6 +41,135 @@ RSpec.describe RubyLLM::Contract::Step::RetryPolicy do
     it "allows custom retryable statuses" do
       policy = described_class.new { retry_on :parse_error }
       expect(policy.retryable_statuses).to eq([:parse_error])
+    end
+  end
+
+  describe "deprecation: :adapter_error in default retry_on" do
+    before { described_class.reset_deprecation_warnings! }
+
+    it "warns only once per process even across many policy constructions" do
+      expect do
+        5.times { described_class.new { attempts 3 } }
+      end.to output(/\A\[ruby_llm-contract\] DEPRECATION.*\n\z/m).to_stderr
+    end
+
+    it "warns when attempts > 1 without escalation and default retry_on" do
+      expect { described_class.new { attempts 3 } }
+        .to output(/DEPRECATION.*adapter_error.*0\.7\.0/m).to_stderr
+    end
+
+    it "does not warn when user explicitly passes retry_on via DSL" do
+      expect do
+        described_class.new do
+          attempts 3
+          retry_on :validation_failed, :parse_error, :adapter_error
+        end
+      end.not_to output(/DEPRECATION/).to_stderr
+    end
+
+    it "does not warn when user explicitly passes retry_on keyword" do
+      expect { described_class.new(attempts: 3, retry_on: %i[adapter_error parse_error]) }
+        .not_to output(/DEPRECATION/).to_stderr
+    end
+
+    it "does not warn with escalation chain of 2+ models (:adapter_error is meaningful there)" do
+      expect { described_class.new { escalate "nano", "mini" } }
+        .not_to output(/DEPRECATION/).to_stderr
+    end
+
+    it "warns when escalate has only one model (no real fallback — same model every attempt)" do
+      expect do
+        described_class.new do
+          attempts 3
+          escalate "nano"
+        end
+      end.to output(/DEPRECATION.*adapter_error/m).to_stderr
+    end
+
+    it "does not warn when max_attempts is 1 (no retry happens anyway)" do
+      expect { described_class.new }.not_to output(/DEPRECATION/).to_stderr
+    end
+
+    describe "thread safety (Mutex) — GH PR #12 review" do
+      # Captures Warning.warn output into a StringIO across threads.
+      # Warning.warn defaults to writing to $stderr in MRI, and $stderr is
+      # a shared global, so swapping it for the duration of the block
+      # captures output from all threads.
+      def capture_concurrent_stderr
+        buffer = StringIO.new
+        original = $stderr
+        $stderr = buffer
+        yield
+        buffer.string
+      ensure
+        $stderr = original
+      end
+
+      it "emits exactly once under stress (50 concurrent constructions)" do
+        output = capture_concurrent_stderr do
+          threads = Array.new(50) do
+            Thread.new { described_class.new { attempts 3 } }
+          end
+          threads.each(&:join)
+        end
+
+        expect(output.scan(/DEPRECATION/).size).to eq(1)
+      end
+
+      it "stays correct even when the check-then-set window is forced open" do
+        # Adversarial scheduler: every time a thread reads the flag and sees
+        # `false`, it yields the scheduler before the caller gets a chance to
+        # set the flag. Without the Mutex'd re-check in
+        # warn_adapter_error_default_deprecated!, multiple threads would
+        # observe `false`, both enter the critical region, and both emit.
+        # The double-checked lock inside synchronize catches this.
+        allow(described_class).to receive(:adapter_error_default_warned).and_wrap_original do |original|
+          value = original.call
+          Thread.pass unless value
+          value
+        end
+
+        output = capture_concurrent_stderr do
+          threads = Array.new(20) do
+            Thread.new { described_class.new { attempts 3 } }
+          end
+          threads.each(&:join)
+        end
+
+        expect(output.scan(/DEPRECATION/).size).to eq(1)
+      end
+
+      it "re-emits after reset even under concurrent pressure" do
+        # First burst: all threads contend; exactly one warning.
+        first_output = capture_concurrent_stderr do
+          Array.new(10) { Thread.new { described_class.new { attempts 3 } } }.each(&:join)
+        end
+        expect(first_output.scan(/DEPRECATION/).size).to eq(1)
+
+        described_class.reset_deprecation_warnings!
+
+        # After reset a second burst must emit exactly one more warning
+        # (not zero — flag was cleared; not two — mutex still dedupes).
+        second_output = capture_concurrent_stderr do
+          Array.new(10) { Thread.new { described_class.new { attempts 3 } } }.each(&:join)
+        end
+        expect(second_output.scan(/DEPRECATION/).size).to eq(1)
+      end
+
+      it "does not deadlock when reset is called between constructions" do
+        expect do
+          Timeout.timeout(2) do
+            3.times do
+              described_class.new { attempts 3 }
+              described_class.reset_deprecation_warnings!
+            end
+          end
+        end.not_to raise_error
+      end
+
+      it "exposes the mutex as a Mutex instance (SOLID: depend on abstraction, not duck-typing)" do
+        expect(described_class.deprecation_mutex).to be_a(Mutex)
+      end
     end
   end
 
@@ -149,9 +281,9 @@ RSpec.describe RubyLLM::Contract::Step::RetryPolicy do
         end
 
         expect(policy.config_list).to eq([
-          { model: "gpt-4.1-nano" },
-          { model: "gpt-4.1-mini", reasoning_effort: "high" }
-        ])
+                                           { model: "gpt-4.1-nano" },
+                                           { model: "gpt-4.1-mini", reasoning_effort: "high" }
+                                         ])
       end
     end
 
@@ -162,9 +294,9 @@ RSpec.describe RubyLLM::Contract::Step::RetryPolicy do
         end
 
         expect(policy.config_list).to eq([
-          { model: "gpt-4.1-nano" },
-          { model: "gpt-4.1-mini", reasoning_effort: "high" }
-        ])
+                                           { model: "gpt-4.1-nano" },
+                                           { model: "gpt-4.1-mini", reasoning_effort: "high" }
+                                         ])
       end
     end
 


### PR DESCRIPTION
## Summary

- Deprecate `:adapter_error` in `DEFAULT_RETRY_ON` when no model escalation chain is configured. Scheduled for removal from the default in `0.7.0`; remains available as explicit opt-in.
- Background: `ruby_llm` already retries transport errors (`RateLimitError`, `ServerError`, `ServiceUnavailableError`, `OverloadedError`, timeouts) at the Faraday layer. Retrying on `:adapter_error` against the same model after Faraday gave up is retry × retry with no change in context.
- `:adapter_error` is still meaningful paired with `escalate "model_a", "model_b"` (2+ models) — a different model/provider can bypass what transport retry could not.

## Design notes

- **Emitted once per process** via a class-level flag (`RetryPolicy.adapter_error_default_warned`). Rails reload cycles, inherited `Step` subclasses, or CI with `fail on stderr` won't get spammed. Tests reset via `reset_deprecation_warnings!`.
- **Uses `Warning.warn` directly** instead of `Kernel#warn`, because Ruby 3.4 silences the latter when `$VERBOSE` is `nil` (the default for `ruby file.rb`).
- **Predicate + emitter split** (`should_warn_adapter_error_default?` vs `warn_adapter_error_default_deprecated!`) — SRP at method scope.
- **Single-model `escalate "x"` still warns** — `config_for_attempt` reuses the same config every retry, so this is the no-escalation case the warning describes (requires `@configs.size >= 2` to suppress).

## Migration

Silence the warning by being explicit about `retry_on`:

- **Keep current behavior:** `retry_on :validation_failed, :parse_error, :adapter_error`
- **Adopt future default:** `retry_on :validation_failed, :parse_error`
- **Use `:adapter_error` meaningfully:** `retry_policy do; attempts 2; escalate "model_a", "model_b"; end`

## Test plan

- [x] `bundle exec rspec` — 1342 examples, 0 failures, 8 pending (unrelated, API-key gated)
- [x] `bundle exec rubocop lib/ruby_llm/contract/step/retry_policy.rb spec/ruby_llm/contract/step/retry_policy_spec.rb` — clean
- [x] Manual verification: `ruby -Ilib -rruby_llm/contract -e '$VERBOSE = false; RubyLLM::Contract::Step::RetryPolicy.new { attempts 3 }'` emits the warning once
- [x] 7 new specs cover: warn once per process, warn on defaults, no warn with explicit `retry_on` (DSL/keyword), no warn with 2+ escalation chain, warn on single-model escalate, no warn at `max_attempts = 1`

Full rationale: `docs/ideas/11_ruby_llm_overlap_analysis.md` (H20) + Codex-verified in `11b_codex_verification.md` (both local scratch, not shipped).
