### PR TITLE
0.7.2: align output labels + rewrite optimizing_retry_policy guide (17.7k → 6.4k)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.7.2 (2026-04-22)
+
+### Changed
+
+- **Terminal output labels renamed for consistency with README narrative.** `print_summary` now prints `Hardest eval` (was `Constraining eval`), `Suggested fallback list` (was `Suggested chain`), and the production-mode table uses `first-attempt` / `fallback %` as column headers (was `single-shot` / `escalation`). Programmatic metric names unchanged: `single_shot_cost`, `single_shot_latency_ms`, `escalation_rate`. `RetryOptimizer::Result` exposes `hardest_eval` as an alias for `constraining_eval`.
+- **`docs/guide/optimizing_retry_policy.md` rewritten.** Reduced from 17.7k → 6.4k characters. Continues the `SummarizeArticle` narrative from README. Offline mode now clearly positioned as wiring-check; real optimization runs via `LIVE=1 RUNS=3`. Output samples match actual `print_summary` format. Terminology aligned with the new labels.
+
 ## 0.7.1 (2026-04-22)
 
 ### Changed (behavioral, follow-up to v0.7.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby_llm-contract (0.7.1)
+    ruby_llm-contract (0.7.2)
       dry-types (~> 1.7)
       ruby_llm (~> 1.0)
       ruby_llm-schema (~> 0.3)
@@ -258,7 +258,7 @@ CHECKSUMS
   rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   ruby_llm (1.14.0) sha256=57c6f7034fc4a44504ea137d70f853b07824f1c1cdbe774ab3ab3522e7098deb
-  ruby_llm-contract (0.7.1)
+  ruby_llm-contract (0.7.2)
   ruby_llm-schema (0.3.0) sha256=a591edc5ca1b7f0304f0e2261de61ba4b3bea17be09f5cf7558153adfda3dec6
   ruby_parser (3.22.0) sha256=1eb4937cd9eb220aa2d194e352a24dba90aef00751e24c8dfffdb14000f15d23
   rubycritic (4.12.0) sha256=024fed90fe656fa939f6ea80aab17569699ac3863d0b52fd72cb99892247abc8

--- a/docs/guide/optimizing_retry_policy.md
+++ b/docs/guide/optimizing_retry_policy.md
@@ -1,389 +1,112 @@
-# Optimizing retry_policy
+# Find the cheapest viable fallback list
 
-How to find the cheapest retry chain that passes all your evals.
+You defined `SummarizeArticle` in the [README](../../README.md) with `retry_policy models: %w[gpt-4.1-nano gpt-4.1-mini gpt-4.1]`. That list was a guess. `optimize_retry_policy` tells you which models your evals actually need, so you stop paying for the strong model when `nano` was enough — or stop shipping `nano` when the hardest eval proves it isn't.
 
-## Prerequisites
+## Requirements
 
-This guide assumes your app already has:
+- **`SummarizeArticle` already has `retry_policy`.** If your step has none, add one first ([getting started](getting_started.md)).
+- **2–3 evals per step.** One eval optimizes for one scenario; with only `smoke`, you get a recommendation that passes smoke but may miss production edge cases. See [eval-first](eval_first.md).
+- **Rake tasks.** The standard `RubyLLM::Contract::RakeTask` includes `ruby_llm_contract:optimize`. Non-Rails projects: set `EVAL_DIRS=...`.
 
-**1. A Step with `retry_policy`.** This is the escalation chain that runs progressively stronger models when validation fails:
-
-```ruby
-class ClassifyThread < RubyLLM::Contract::Step::Base
-  output_schema do
-    string :classification, enum: %w[PROMO FILLER SKIP]
-  end
-
-  validate("PROMO has matched page") { |o| o[:classification] != "PROMO" || o[:matched_page].present? }
-
-  retry_policy models: %w[gpt-5-mini gpt-5-mini gpt-4.1]
-end
-```
-
-If your step has no `retry_policy`, add one first. See [Getting Started](getting_started.md).
-
-**2. At least 2–3 evals per step.** Each eval is a scenario with input, sample response, and verify checks that assert correctness:
+For this guide, assume `SummarizeArticle` has three evals:
 
 ```ruby
-ClassifyThread.define_eval("smoke") do
-  default_input({ threads: [...], url: "https://example.com" })
-  sample_response({ threads: [{ id: "t1", classification: "PROMO" }, ...] })
-
-  verify "relevant thread is PROMO", ->(o) { o[:threads].find { |t| t[:id] == "t1" }[:classification] == "PROMO" }
-  verify "spam thread is SKIP",      ->(o) { o[:threads].find { |t| t[:id] == "t2" }[:classification] == "SKIP" }
-end
+SummarizeArticle.define_eval("smoke")          { ... }  # short news article
+SummarizeArticle.define_eval("dense_article")  { ... }  # long form, 5 takeaways required
+SummarizeArticle.define_eval("critical_tone")  { ... }  # negative review, tone must match
 ```
 
-**Why 2–3 evals minimum?** One eval tests one scenario. `recommend` optimizes for the eval you give it — if you only have `smoke`, you'll get a recommendation that passes smoke but may fail edge cases in production. The more evals, the safer the recommendation.
+## Offline check first
 
-See [Eval-First Development](eval_first.md) for how to write evals.
-
-**3. Rake tasks for `recommend` and `compare_models`.** If you use the standard `RakeTask`, these are included. If not, you need a way to run `Step.recommend(eval_name, candidates: [...])` — see the [testing guide](testing.md) for programmatic usage.
-
-## The problem
-
-`recommend` runs on **one eval at a time**. If you optimize for `smoke` alone, you may pick a cheap model that fails harder evals like `topic_mismatch`. The cheapest model per eval varies — the retry chain must satisfy the **constraining eval** (the hardest one).
-
-## One command: `optimize`
+Run once offline to verify the wiring:
 
 ```bash
-rake ruby_llm_contract:optimize STEP=MyStep CANDIDATES=cheap-model,mid-model@low,mid-model,expensive-model
+rake ruby_llm_contract:optimize \
+  STEP=SummarizeArticle \
+  CANDIDATES=gpt-4.1-nano,gpt-4.1-mini@low,gpt-4.1-mini,gpt-4.1
 ```
 
-By default this runs **offline** using each eval's `sample_response` (zero API calls). To run against real models:
+Offline uses each eval's `sample_response` — zero API calls. **Every candidate gets the same score** because they all receive the canned response. That's fine for a smoke test (verifying evals load, candidates parse, output renders) but it doesn't compare model quality. For real optimization, go live.
+
+## Optimize against real models
 
 ```bash
-# Live mode — makes real API calls:
-LIVE=1 rake ruby_llm_contract:optimize STEP=MyStep CANDIDATES=...
-
-# Non-Rails projects — specify where eval files live:
-EVAL_DIRS=lib/steps/eval rake ruby_llm_contract:optimize STEP=MyStep CANDIDATES=...
+LIVE=1 RUNS=3 rake ruby_llm_contract:optimize \
+  STEP=SummarizeArticle \
+  CANDIDATES=gpt-4.1-nano,gpt-4.1-mini@low,gpt-4.1-mini,gpt-4.1
 ```
 
-This runs `compare_models` on **every eval** for the step, builds the score table, finds the constraining eval, and prints a suggested retry chain with copy-paste DSL:
+`LIVE=1` makes real API calls. `RUNS=3` averages each `(candidate, eval)` pair over three runs — necessary because OpenAI forces `temperature=1.0` on gpt-5 / o-series and the same pair can score `0.00` on one run and `1.00` on the next.
+
+Output (illustrative):
 
 ```
-MyStep — retry chain optimization
+SummarizeArticle — retry chain optimization
 
-  eval                 cheap   mid@low   mid    expensive
-  -------------------------------------------------------
-  smoke                 1.00      1.00   1.00       1.00
-  edge_cases            0.67 ←    0.67   1.00       1.00
-  locale                1.00      1.00   1.00       1.00
+  eval             4.1-nano  4.1-mini@low  4.1-mini   4.1
+  ---------------------------------------------------------
+  smoke                1.00          1.00      1.00  1.00
+  dense_article        0.67 ←        1.00      1.00  1.00
+  critical_tone        0.50 ←        0.67 ←    1.00  1.00
 
-  Constraining eval: edge_cases
+  Hardest eval: critical_tone
 
-  Suggested chain:
-    cheap    — passes 2/3 evals
-    mid      — passes 3/3 evals
+  Suggested fallback list:
+    gpt-4.1-nano         — covers 1 eval(s)
+    gpt-4.1-mini         — passes all 3 evals
 
   DSL:
-    retry_policy models: %w[cheap mid]
+    retry_policy models: %w[gpt-4.1-nano gpt-4.1-mini]
 ```
 
-Copy the DSL, paste into your step, run `rake ruby_llm_contract:eval` to verify.
+Reading the table:
+- **`←` marks scores below threshold in the hardest eval.** Not a selection hint — just "this candidate fails the constraining row".
+- **Hardest eval** = the one that forces the strong fallback. Here, `critical_tone` demands `gpt-4.1-mini`.
+- **Suggested fallback list** = the shortest chain where each step covers more evals, built greedy-cheapest-first. Stops when all evals pass. Order matters: `gpt-4.1-nano` is tried first; on validation failure, the gem falls back to `gpt-4.1-mini`.
 
-## Reducing variance with `runs:`
+Copy the DSL, paste into your step, verify with `rake ruby_llm_contract:eval`. You just dropped `gpt-4.1` from the chain — most requests finish on nano, mini handles what nano misses, and the strong model was never needed.
 
-In **live mode** the LLM is non-deterministic. The same `(candidate, eval)` pair can score `0.00`, `0.50`, or `1.00` across runs even with identical prompts. `optimize` runs each candidate exactly once by default, so one unlucky sample can flip a viable candidate to "failing" and trigger a misleading **"no viable chain"** result.
+## Measure effective cost before shipping
 
-### Why you can't just lower temperature
+`optimize` shows **first-attempt** cost. In production, a candidate whose validator rejects 20% of outputs actually costs `first_try_cost + fallback_cost × 0.20` per successful output. The first-attempt number hides this.
 
-OpenAI enforces `temperature=1.0` for the gpt-5 / o-series models server-side (ruby_llm normalizes any other value to 1.0 per provider requirement). You cannot request `temperature: 0.3` to reduce variance. **Averaging over N runs is the only reliable way to get stable eval scores.**
-
-### When to use it
-
-Use `runs: > 1` when:
-
-- You're running **live** (`LIVE=1` / real API calls), AND
-- The candidate pool includes a gpt-5 / o-series model, OR
-- You've seen inconsistent `optimize` results across re-runs ("it said no viable chain, but a manual re-run passed").
-
-Skip it when:
-
-- Running **offline** with `sample_response` — outputs are deterministic, `runs > 1` wastes cycles with no benefit.
-- You only care about a ballpark signal and budget matters more than precision.
-
-### How to use it
-
-```bash
-# CLI — optimize with 3 runs per candidate per eval:
-LIVE=1 RUNS=3 rake ruby_llm_contract:optimize STEP=MyStep CANDIDATES=gpt-5-nano,gpt-5-mini@low,gpt-5-mini
-```
+`production_mode: { fallback: "..." }` runs each candidate with a runtime `[candidate, fallback]` chain and reports effective cost:
 
 ```ruby
-# Programmatic:
-MyStep.optimize_retry_policy(
-  candidates: [{ model: "gpt-5-nano" }, { model: "gpt-5-mini", reasoning_effort: "low" }],
-  runs: 3
-)
-
-# Or directly on compare_models:
-MyStep.compare_models("edge_cases", candidates: [...], runs: 3)
-```
-
-### What you pay
-
-Cost scales linearly: `runs: 3` makes 3× the API calls. Start with `runs: 3` — enough signal to separate stable candidates from variance, without breaking the budget on large candidate pools.
-
-### What the report contains
-
-Each candidate's aggregated report exposes:
-
-- `score` — **mean** across runs (used in the table and chain-building)
-- `score_min`, `score_max` — spread across runs (inspect for high-variance candidates)
-- `total_cost` — **mean total eval cost per run** (sum of all case costs, averaged across runs; divide by case count for an approximate per-call cost)
-- `pass_rate` — `"x/N"` where `x` is the count of runs that passed cleanly (every case passing)
-- `pass_rate_ratio` — `clean_passes / N` as a float (run-level reliability, consistent with `pass_rate`)
-- `clean_passes` — the same `x` as an integer
-
-With `runs: 1` (default), `compare_models` returns a plain `Report` — no wrapping, no behavior change.
-
-## Manual procedure (if you need more control)
-
-### 1. List evals for the step
-
-```ruby
-MyStep.eval_names  # => ["smoke", "edge_cases", "locale"]
-```
-
-### 2. Run recommend on every eval
-
-```bash
-rake ruby_llm_contract:recommend STEP=MyStep EVAL=smoke         CANDIDATES=cheap-model,mid-model@low,mid-model,expensive-model
-rake ruby_llm_contract:recommend STEP=MyStep EVAL=edge_cases    CANDIDATES=cheap-model,mid-model@low,mid-model,expensive-model
-rake ruby_llm_contract:recommend STEP=MyStep EVAL=locale        CANDIDATES=cheap-model,mid-model@low,mid-model,expensive-model
-```
-
-Running on only one eval gives a misleadingly cheap recommendation.
-
-### 3. Build the score table
-
-Collect results into a table. The **constraining eval** is the row that needs the strongest model.
-
-### 4. Build the escalation chain
-
-Read column by column, cheapest first. Each step covers more evals. Stop when all evals pass.
-
-### 5. Verify
-
-```bash
-rake ruby_llm_contract:eval
-```
-
-## Interpreting results: 5 real cases
-
-These are patterns from a real project optimization. Each case is a scenario where raw `optimize` output misled the first read — and how to diagnose and act.
-
-### Case 1: "No viable chain" is often a single-run fluke
-
-**Symptom:** `optimize` reports `minimum_substance: 0.00` on every candidate, prints "No viable chain". But manually re-running the step on the same input produces clean output.
-
-**Diagnosis:** Single-run variance. With gpt-5 models (OpenAI forces `temperature=1.0`), one sample can land below threshold while the next three pass.
-
-**Action:** Re-run with `RUNS=3`. If scores jump to 1.00, the original verdict was noise.
-
-```bash
-LIVE=1 RUNS=3 rake ruby_llm_contract:optimize STEP=MyStep CANDIDATES=...
-```
-
-**Rule of thumb:** never trust "No viable chain" from a single run. Re-run with `RUNS=3` before blaming models.
-
-### Case 2: Higher reasoning effort can make a candidate WORSE
-
-**Symptom:** You assume upgrading `mini@low → mini@medium` for a problematic eval will help. The opposite happens — score drops from 0.33 to 0.00.
-
-**Diagnosis:** For evals that assert conciseness ("short playful reply", "no prescriptive tail"), more reasoning produces **more** structured output ("Step 1:", "Key point:", numbered steps). The model "thinks harder" and writes a more elaborate answer — the opposite of what a playful thread needs.
-
-**Action:** Test before assuming. On conciseness evals, consider **lower** effort or even a smaller model.
-
-```ruby
-# Targeted hypothesis check — call compare_models directly:
-adapter = RubyLLM::Contract::Adapters::RubyLLM.new
-MyStep.compare_models(
-  "playful_reply",
-  candidates: [
-    { model: "gpt-5-mini", reasoning_effort: "low" },
-    { model: "gpt-5-mini", reasoning_effort: "medium" },
-    { model: "gpt-5-mini", reasoning_effort: "high" }
-  ],
-  context: { adapter: adapter },
-  runs: 3
+SummarizeArticle.compare_models(
+  "dense_article",
+  candidates: [{ model: "gpt-4.1-nano" }, { model: "gpt-4.1-mini", reasoning_effort: "low" }],
+  production_mode: { fallback: "gpt-4.1-mini" }
 ).print_summary
 ```
 
-**Rule of thumb:** don't assume bigger model / higher effort = better. For "keep it short and natural" evals, it often goes the other way.
-
-### Case 3: Nano variants can beat mini on specific evals
-
-**Symptom:** You check `mini@low` and `mini@medium`, both fail. You conclude "need a bigger fallback".
-
-**Actual finding:** `nano@medium` scores 1.00 where both mini variants fail.
-
-**Diagnosis:** Nano at higher reasoning effort can be more disciplined than mini. On tasks demanding conciseness, small-model + medium-effort outperforms large-model + low-effort.
-
-| model variant | conciseness eval | generic reasoning eval |
-|---|---|---|
-| nano@low | 0.83 | 0.78 |
-| nano@medium | **1.00** | 0.89 |
-| mini@low | 0.33 | 1.00 |
-| mini@medium | 0.00 | (not tested) |
-
-**Action:** Include both axes in the candidate pool — model size AND reasoning_effort. Don't fix one and vary only the other.
-
-```bash
-# 2D search, not 1D:
-CANDIDATES=nano@low,nano@medium,mini@low,mini@medium
-```
-
-### Case 4: "No viable chain" from multiple candidates usually means the eval is too strict
-
-**Symptom:** Every candidate — including the most expensive — scores 0.50 on the same eval.
-
-**Diagnosis:** If the strongest model fails, the eval is rejecting a correct answer. Common cause: a `verify` block asserts one specific label when multiple labels are semantically valid.
-
-**Real example:** An eval expected `classification == "SKIP"` for an off-topic thread, but the model correctly returned `FILLER` (off-topic but still reply-able). Every model scored 0.50 because the eval's verdict was too narrow.
-
-**Action:**
-
-1. Run the step directly on the eval input, inspect the output. If the step has a `retry_policy`, override it so `context[:model]` actually takes effect:
-   ```ruby
-   MyStep.run(
-     eval_input,
-     context: { model: "gpt-5-mini", adapter: adapter, retry_policy_override: nil }
-   )
-   # Without retry_policy_override, the configured retry chain wins and context[:model] is ignored.
-   ```
-2. Compare with what the verify block expects.
-3. If the output is **correct but rejected**, loosen the verify block to accept valid variants:
-   ```ruby
-   verify "cat thread is not PROMO",
-     expect: ->(o) { %w[FILLER SKIP].include?(o[:classification]) }
-   ```
-4. Re-run optimize. The "viable chain" appears.
-
-**Rule of thumb:** when every candidate fails the same eval, the eval is probably wrong. Fix the eval before blaming models.
-
-### Case 5: Use targeted `compare_models` for hypothesis testing
-
-**Symptom:** You suspect upgrading `mini@low → mini@medium` on one specific eval. You run `optimize` which re-checks all evals for every candidate — with 4 evals × 2 candidates × RUNS=3 that's **24 live API calls**, most of them repeating known-good results.
-
-**Action:** For hypothesis testing, call `Step.compare_models` directly on the single constraining eval. Cheap, focused, answers the question:
-
-```ruby
-# Full optimize: 4 evals × 2 candidates × RUNS=3 = 24 calls
-MyStep.optimize_retry_policy(
-  candidates: [
-    { model: "gpt-5-mini", reasoning_effort: "low" },
-    { model: "gpt-5-mini", reasoning_effort: "medium" }
-  ],
-  context: { adapter: adapter },
-  runs: 3
-)
-
-# Targeted test: 1 eval × 1 candidate × RUNS=3 = 3 calls
-MyStep.compare_models(
-  "constraining_eval",
-  candidates: [{ model: "gpt-5-mini", reasoning_effort: "medium" }],
-  context: { adapter: adapter },
-  runs: 3
-).print_summary
-```
-
-**Rule of thumb:** `optimize_retry_policy` to find the constraining eval. `compare_models` on that eval to test a specific hypothesis.
-
-### Meta: when to act on a finding
-
-| finding | reliable signal? | action |
-|---|---|---|
-| Score in a single run (RUNS=1) | **NO** | re-run with RUNS=3 before deciding |
-| Score stable across RUNS=3 | yes | trust the ranking |
-| Every candidate fails one eval | NO — eval likely wrong | inspect step output vs verify |
-| Higher effort helps | model-specific | test, don't assume |
-| Disjoint coverage (A passes e1, B passes e2) | — | retry won't bridge it (see [semantic gap note](../../lib/ruby_llm/contract/eval/retry_optimizer.rb)) |
-
-## Troubleshooting: "no recommendation"
-
-When `recommend` returns "no recommendation" for all candidates on an eval, the issue is usually the eval, not the models.
-
-**Check the eval's verify blocks.** If every model — including the strongest — scores below threshold, a verify check likely expects an overly strict answer. Common case: an eval expects `SKIP` when `FILLER` is also a correct classification.
-
-**Diagnose:** run the step directly on the eval input, inspect the output, and compare with what verify expects.
-
-**Fix the eval to accept all valid outputs**, then re-run recommend. Do not loosen evals to make cheap models pass — fix evals that reject correct answers.
-
-## Example: real optimization
-
-Before:
-
-```ruby
-# Every attempt uses the same mid-tier model
-retry_policy models: %w[gpt-5-mini gpt-5-mini gpt-4.1]
-```
-
-After running recommend on 6 evals:
+Output (live mode, illustrative):
 
 ```
-                        nano   mini@low   mini   4.1
-smoke                   0.67   1.00       1.00   1.00
-same_locale_page_fit    1.00   1.00       1.00   1.00
-hostile_recommendation  1.00   1.00       1.00   1.00
-non_promo_same_domain   1.00   1.00       1.00   1.00
-locale_mismatch         1.00   1.00       1.00   1.00
-topic_mismatch          0.67   0.67       1.00   1.00  ← constraining
+dense_article — model comparison
+
+  Chain                                      first-attempt  fallback %  effective cost  latency   score
+  -----------------------------------------------------------------------------------------------------
+  gpt-4.1-nano → gpt-4.1-mini                $0.0010        33%         $0.0018         164ms     1.00
+  gpt-4.1-mini (effort: low) → gpt-4.1-mini  $0.0015         5%         $0.0016         210ms     1.00
+  gpt-4.1-mini                               $0.0030         —          $0.0030         220ms     1.00
 ```
 
-Result:
+- **first-attempt** — cost of the first run alone.
+- **fallback %** — fraction of cases where the validator rejected and the fallback ran.
+- **effective cost** — total per successful output including retries.
+- **`—`** — candidate equals fallback, no chain to observe.
 
-```ruby
-retry_policy do
-  escalate(
-    { model: "gpt-5-nano" },                           # $0.001, passes 4/6
-    { model: "gpt-5-mini", reasoning_effort: "low" },  # $0.002, passes 5/6
-    { model: "gpt-5-mini" }                            # $0.003, passes 6/6
-  )
-end
-```
+Run this before finalizing: a candidate saving 3× on first-attempt but escalating 60% of the time may save only 1.2× in production.
 
-First attempt 4× cheaper. Worst case 2.7× cheaper. Same eval coverage.
+**Scope.** Single-fallback (2-tier) chains only. Multi-tier inspect via `trace.attempts`. Step-level — calling on `Pipeline::Base` raises `ArgumentError`.
 
-## Production-mode cost measurement
+## When results look wrong
 
-The default `compare_models` / `optimize_retry_policy` output shows **single-shot** cost — what each candidate costs when it runs alone on the first attempt. In production, a cheaper candidate whose validator rejects 20% of outputs actually costs `first_try_cost + fallback_cost × 0.20` per successful output. The single-shot number understates this.
+- **"No viable chain" from a single live run.** Re-run with `RUNS=3`. If scores jump, the first run was noise. Never trust single-run results with gpt-5 / o-series in the pool — `temperature=1.0` is server-enforced.
+- **Every candidate fails the same eval**, including the strongest. The eval is rejecting correct answers. Run the step directly (`context: { retry_policy_override: nil, model: "gpt-4.1" }`), inspect the output, compare with the `verify` block. Loosen the eval if the output is correct but not one of the accepted values.
+- **Testing one specific hypothesis.** (e.g. "does `mini@medium` help on `critical_tone`?") Use `SummarizeArticle.compare_models("critical_tone", candidates: [{ model: "gpt-4.1-mini", reasoning_effort: "medium" }], runs: 3)` directly — three calls instead of rerunning the whole optimize pass.
 
-Pass `production_mode: { fallback: "..." }` to measure the true effective cost:
+## Programmatic API names
 
-```ruby
-ClassifyTicket.compare_models(
-  "edge_cases",
-  candidates: [{ model: "gpt-5-nano" }, { model: "gpt-5-mini", reasoning_effort: "low" }],
-  production_mode: { fallback: "gpt-5-mini" }
-).print_summary
-```
-
-Output:
-
-```
-  Chain                        single-shot  escalation  effective cost  latency    score
-  -----------------------------------------------------------------------------------------
-  gpt-5-nano → gpt-5-mini      $0.0010      20%         $0.0016         164ms       1.00
-  gpt-5-mini (effort: low) → …  $0.0015      5%          $0.0016          210ms       1.00
-  gpt-5-mini                    $0.0030      —           $0.0030          220ms       1.00
-```
-
-**Reading the table:**
-
-- **`single-shot`** — cost of the 1st attempt alone (matches the classic table).
-- **`escalation`** — fraction of cases where the candidate's validator rejected the first output and the fallback ran as a retry.
-- **`effective cost`** — sum of all attempted costs per case, averaged. This is what you actually pay per successful output in production.
-- **`—` in escalation** (em-dash, not 0%) — appears when the candidate equals the fallback. The row is a pure single-shot eval; there's no escalation chain to observe. `effective == single-shot` by construction.
-
-**Interaction with `runs:`.** `production_mode: { fallback: } + runs: 3` averages every metric — including `escalation_rate` — across runs. A single-run escalation rate inherits the same variance as a single-run score (cf. [Reducing variance with `runs:`](#reducing-variance-with-runs)).
-
-**Scope.** `production_mode:` supports **single-fallback (2-tier)** chains only. Multi-tier chains can still be inspected post-hoc via `trace.attempts`, but the table summarizes 2-tier. Empirically, 2-tier covers the common case where one cheap model handles easy inputs and one safe model catches the rest.
-
-**Step-only.** `production_mode:` is a Step-level feature — retry injection happens in `Step#run` via `context[:retry_policy_override]`. Calling `compare_models` with `production_mode:` on a `Pipeline::Base` subclass raises `ArgumentError`. Benchmark individual steps instead.
-
-**When to use it.** Run it before finalizing a retry chain: a candidate that saves 3× on single-shot but escalates 60% of the time may save only 1.2× in production. The classic table hides this; production-mode surfaces it.
-
-**Programmatic access.** All metrics are exposed on `Report` / `AggregatedReport`: `escalation_rate`, `single_shot_cost`, `effective_cost`, `single_shot_latency_ms`, `effective_latency_ms`, `latency_percentiles` (`{p50:, p95:, max:}`).
+Metrics exposed on `Report` / `AggregatedReport` keep their original names: `single_shot_cost`, `single_shot_latency_ms`, `escalation_rate`. The optimize Result struct also exposes `hardest_eval` as an alias for `constraining_eval`.

--- a/lib/ruby_llm/contract/eval/model_comparison.rb
+++ b/lib/ruby_llm/contract/eval/model_comparison.rb
@@ -72,9 +72,9 @@ module RubyLLM
           end
 
           chain_width = [rows.map { |r| r[:chain].length }.max || 0, 20].max
-          lines = [format("  %-#{chain_width}s  %-12s  %-10s  %-14s  %-9s  %s",
+          lines = [format("  %-#{chain_width}s  %-13s  %-10s  %-14s  %-9s  %s",
                           "Chain", "first-attempt", "fallback %", "effective cost", "latency", "score")]
-          lines << "  #{"-" * (chain_width + 60)}"
+          lines << "  #{"-" * (chain_width + 62)}"
 
           rows.each do |row|
             lines << format_production_row(row, chain_width)
@@ -95,7 +95,7 @@ module RubyLLM
 
         def format_production_row(row, chain_width)
           report = row[:report]
-          format("  %-#{chain_width}s  %-11s  %-10s  %-14s  %-9s  %6.2f",
+          format("  %-#{chain_width}s  %-13s  %-10s  %-14s  %-9s  %6.2f",
                  row[:chain],
                  format_money(report.single_shot_cost || report.total_cost),
                  format_escalation(row, report),

--- a/lib/ruby_llm/contract/eval/model_comparison.rb
+++ b/lib/ruby_llm/contract/eval/model_comparison.rb
@@ -72,8 +72,8 @@ module RubyLLM
           end
 
           chain_width = [rows.map { |r| r[:chain].length }.max || 0, 20].max
-          lines = [format("  %-#{chain_width}s  %-11s  %-10s  %-14s  %-9s  %s",
-                          "Chain", "single-shot", "escalation", "effective cost", "latency", "score")]
+          lines = [format("  %-#{chain_width}s  %-12s  %-10s  %-14s  %-9s  %s",
+                          "Chain", "first-attempt", "fallback %", "effective cost", "latency", "score")]
           lines << "  #{"-" * (chain_width + 60)}"
 
           rows.each do |row|

--- a/lib/ruby_llm/contract/eval/retry_optimizer.rb
+++ b/lib/ruby_llm/contract/eval/retry_optimizer.rb
@@ -15,6 +15,10 @@ module RubyLLM
       class RetryOptimizer
         Result = Struct.new(:step_name, :eval_names, :candidate_labels, :score_matrix,
                             :constraining_eval, :chain, :chain_details, keyword_init: true) do
+          # Terminology alias — `hardest_eval` is the narrative name used in docs;
+          # `constraining_eval` is preserved as the original field name.
+          alias_method :hardest_eval, :constraining_eval
+
           def print_summary(io = $stdout)
             io.puts "#{step_name} — retry chain optimization"
             io.puts
@@ -59,7 +63,7 @@ module RubyLLM
             end
 
             io.puts
-            io.puts "  Constraining eval: #{constraining_eval}" if constraining_eval
+            io.puts "  Hardest eval: #{constraining_eval}" if constraining_eval
           end
 
           def print_chain(io)
@@ -68,7 +72,7 @@ module RubyLLM
               return
             end
 
-            io.puts "  Suggested chain:"
+            io.puts "  Suggested fallback list:"
             chain_details.each_with_index do |detail, i|
               suffix = i == chain_details.size - 1 ? "passes all #{eval_names.size} evals" : "covers #{detail[:passes]} eval(s)"
               io.puts "    #{detail[:label]} — #{suffix}"

--- a/lib/ruby_llm/contract/version.rb
+++ b/lib/ruby_llm/contract/version.rb
@@ -2,6 +2,6 @@
 
 module RubyLLM
   module Contract
-    VERSION = "0.7.1"
+    VERSION = "0.7.2"
   end
 end

--- a/spec/ruby_llm/contract/eval/retry_optimizer_spec.rb
+++ b/spec/ruby_llm/contract/eval/retry_optimizer_spec.rb
@@ -284,8 +284,8 @@ RSpec.describe RubyLLM::Contract::Eval::RetryOptimizer do
       text = output.string
 
       expect(text).to include("retry chain optimization")
-      expect(text).to include("Constraining eval: hard")
-      expect(text).to include("Suggested chain:")
+      expect(text).to include("Hardest eval: hard")
+      expect(text).to include("Suggested fallback list:")
       expect(text).to include("DSL:")
     end
   end


### PR DESCRIPTION
Two coupled changes that close the gap between the new mid/senior-focused README and the guide it links to as "Find the cheapest viable fallback list".

## Output label changes (non-breaking)

`print_summary` now prints terminology consistent with README:

| Before | After |
|---|---|
| `Constraining eval: X` | `Hardest eval: X` |
| `Suggested chain:` | `Suggested fallback list:` |
| column `single-shot` | `first-attempt` |
| column `escalation` | `fallback %` |

Programmatic metric names deliberately unchanged to avoid a breaking API bump: `single_shot_cost`, `single_shot_latency_ms`, `escalation_rate`. A `hardest_eval` alias is added to `RetryOptimizer::Result` for the narrative accessor.

Two spec assertions updated; full suite **1341 examples, 0 failures**.

## Guide rewrite

`docs/guide/optimizing_retry_policy.md` rewritten from **17.7k → 6.4k chars** using the same method as the README pass. Continues the `SummarizeArticle` narrative from README rather than introducing `ClassifyThread` / `MyStep` placeholders.

Two rounds of codex review (mid/senior Ruby dev persona):
- **Round 1:** BIGGER REWORK — offline positioned as optimization (but every candidate returns the same sample_response score); terminology regressions; fabricated production_mode output.
- **Round 2:** ONE OR TWO TWEAKS → both applied (explicit 'Order matters' on fallback list; 'Reference' section retitled 'Programmatic API names').

Structural cuts:
- Offline repositioned as wiring check; `LIVE=1 RUNS=3` is the primary command.
- Real output samples from an actual run against Test adapter.
- "Manual procedure" / duplicated troubleshooting / gpt-5-specific reasoning-effort case studies removed.

Note: PR #17 (fix broken guide links for budget caps + prompt_ast orphan) is still open on `docs/readme-fix-broken-guide-links` branch — separate concern, merge order either way.