### PR TITLE
docs(output-schema): fix camelCase DSL bug (copy-paste raised ArgumentError)

### DIFF
--- a/docs/guide/output_schema.md
+++ b/docs/guide/output_schema.md
@@ -78,6 +78,8 @@ end
 |-----------|-------|---------|
 | `enum` | string, integer | `string :status, enum: %w[active inactive]` |
 | `minimum` / `maximum` | number, integer | `number :score, minimum: 0, maximum: 100` |
-| `minLength` / `maxLength` | string | `string :name, minLength: 1, maxLength: 100` |
-| `minItems` / `maxItems` | array | `array :tags, minItems: 1, maxItems: 10` |
-| `additionalProperties` | object | Set to `false` in schema to reject extra keys |
+| `min_length` / `max_length` | string | `string :name, min_length: 1, max_length: 100` |
+| `min_items` / `max_items` | array | `array :tags, min_items: 1, max_items: 10` |
+| `additional_properties` | object | Set to `false` in schema to reject extra keys |
+
+Keyword args use Ruby snake_case (`min_length`, `min_items`). The DSL converts them internally to JSON Schema's camelCase (`minLength`, `minItems`) before sending the schema to the provider — you do not need to write camelCase in Ruby.


### PR DESCRIPTION
## Blocker found in content audit

`docs/guide/output_schema.md` documented DSL keywords in camelCase (`minLength`, `maxLength`, `minItems`, `maxItems`, `additionalProperties`). **These are JSON Schema spec names, not the actual `ruby_llm-schema` DSL.**

The DSL accepts snake_case (`min_length`, `min_items`, etc.) and converts internally to camelCase before sending the schema to the provider (verified in `schema_builders.rb:7-12, 78-85`).

Every copy-paste from the previous table would have raised `ArgumentError` when the schema was built. Fixed across the table, added a one-line note on the internal conversion so readers who know the JSON Schema names aren't confused.

## Verification

`tmp/verify_schema_dsl.rb` builds a schema using every constraint from the table in snake_case (`min_length`, `max_length`, `min_items`, `max_items`) and dumps the resulting JSON Schema. Everything round-trips cleanly to the expected `minLength` / `minItems` output.

## Companion audit of `prompt_ast.md`

Checked for the same class of issue (invented DSL names). No bugs — `input_type Types::Hash.schema(...)` + `Types::String` etc. all build successfully. No changes needed.

## Scope

Fix only — no narrative rewrite of `output_schema.md`. The guide's case (intent/confidence) is different from README's `SummarizeArticle`, but `output_schema.md` is a DSL reference, not a walkthrough; keeping varied examples there is fine.
