### PR TITLE
0.7.2 + batch: guide optimizations (optimizing_retry_policy + getting_started + output_schema + terminal labels)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.7.2 (2026-04-22)
+
+### Changed
+
+- **Terminal output labels renamed for consistency with README narrative.** `print_summary` now prints `Hardest eval` (was `Constraining eval`), `Suggested fallback list` (was `Suggested chain`), and the production-mode table uses `first-attempt` / `fallback %` as column headers (was `single-shot` / `escalation`). Programmatic metric names unchanged: `single_shot_cost`, `single_shot_latency_ms`, `escalation_rate`. `RetryOptimizer::Result` exposes `hardest_eval` as an alias for `constraining_eval`.
+- **`docs/guide/optimizing_retry_policy.md` rewritten.** Reduced from 17.7k → 6.4k characters. Continues the `SummarizeArticle` narrative from README. Offline mode now clearly positioned as wiring-check; real optimization runs via `LIVE=1 RUNS=3`. Output samples match actual `print_summary` format. Terminology aligned with the new labels.
+
 ## 0.7.1 (2026-04-22)
 
 ### Changed (behavioral, follow-up to v0.7.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@
 ### Changed
 
 - **Terminal output labels renamed for consistency with README narrative.** `print_summary` now prints `Hardest eval` (was `Constraining eval`), `Suggested fallback list` (was `Suggested chain`), and the production-mode table uses `first-attempt` / `fallback %` as column headers (was `single-shot` / `escalation`). Programmatic metric names unchanged: `single_shot_cost`, `single_shot_latency_ms`, `escalation_rate`. `RetryOptimizer::Result` exposes `hardest_eval` as an alias for `constraining_eval`.
-- **`docs/guide/optimizing_retry_policy.md` rewritten.** Reduced from 17.7k → 6.4k characters. Continues the `SummarizeArticle` narrative from README. Offline mode now clearly positioned as wiring-check; real optimization runs via `LIVE=1 RUNS=3`. Output samples match actual `print_summary` format. Terminology aligned with the new labels.
+
+### Documentation
+
+- **`docs/guide/optimizing_retry_policy.md` rewritten** — 17.7k → 6.4k characters. Continues the `SummarizeArticle` narrative from README. Offline mode clearly positioned as wiring-check; real optimization runs via `LIVE=1 RUNS=3`. Output samples match actual `print_summary` format.
+- **`docs/guide/getting_started.md` rewritten** — 8.7k → 6.1k. Every example uses `SummarizeArticle`. Evals + CI gates section moved before Budget caps. Structured Prompts / Dynamic Prompts / "Already using ruby_llm?" / Reasoning effort sections removed; content delegated to `prompt_ast.md` and README.
+- **`docs/guide/eval_first.md` refined** — 6.3k → 5.0k. Switched to `SummarizeArticle` case. Team workflow section compressed with links back to `getting_started.md` for the matcher chain.
+- **`docs/guide/testing.md` refined** — 10.7k → 7.4k. Switched to `SummarizeArticle` case. Threshold gating / Rake task / baseline walkthrough / prompt A/B sections delegated back to `getting_started.md` and `eval_first.md`.
+- **`docs/guide/output_schema.md` DSL bug fix** — the Supported constraints table documented JSON Schema camelCase keys (`minLength`, `minItems`, `additionalProperties`) that are not valid DSL arguments. Every copy-paste from the previous table would have raised `ArgumentError`. Switched to snake_case (`min_length`, `min_items`, `additional_properties`) as the DSL actually expects; added a short note on the internal camelCase conversion.
+- **`docs/guide/best_practices.md`, `pipeline.md`, `migration.md` sanity pass** — terminology alignment (model escalation → model fallback where narrative; `escalate` DSL method unchanged) and `SummarizeArticle` case where the guide is not inherently multi-step.
 
 ## 0.7.1 (2026-04-22)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby_llm-contract (0.7.1)
+    ruby_llm-contract (0.7.2)
       dry-types (~> 1.7)
       ruby_llm (~> 1.0)
       ruby_llm-schema (~> 0.3)
@@ -258,7 +258,7 @@ CHECKSUMS
   rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   ruby_llm (1.14.0) sha256=57c6f7034fc4a44504ea137d70f853b07824f1c1cdbe774ab3ab3522e7098deb
-  ruby_llm-contract (0.7.1)
+  ruby_llm-contract (0.7.2)
   ruby_llm-schema (0.3.0) sha256=a591edc5ca1b7f0304f0e2261de61ba4b3bea17be09f5cf7558153adfda3dec6
   ruby_parser (3.22.0) sha256=1eb4937cd9eb220aa2d194e352a24dba90aef00751e24c8dfffdb14000f15d23
   rubycritic (4.12.0) sha256=024fed90fe656fa939f6ea80aab17569699ac3863d0b52fd72cb99892247abc8

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ You could write this loop yourself once. The gem gives you the loop, a trace of 
 Everything below is optional — the example above is a complete step. Reach for these when one step isn't enough.
 
 - **[CI regression gates](docs/guide/getting_started.md)** — `define_eval` + `save_baseline!` + `pass_eval(...).without_regressions` blocks CI when accuracy drops on a model update or prompt tweak.
-- **[Find the cheapest viable fallback list](docs/guide/optimizing_retry_policy.md)** — `Step.recommend(candidates:, min_score:)` returns the cheapest list of models that still passes your evals. `production_mode:` measures retry-aware cost.
+- **[Find the cheapest viable fallback list](docs/guide/optimizing_retry_policy.md)** — `Step.recommend("regression", candidates: [...], min_score: 0.95)` returns the cheapest list of models that still passes your evals. `production_mode:` measures retry-aware cost.
 - **[A/B test prompts](docs/guide/eval_first.md)** — `SummarizeArticleV2.compare_with(SummarizeArticleV1, eval: "regression")` reports whether the new prompt is safe to ship.
 - **[Budget caps](docs/guide/getting_started.md)** — `max_cost`, `max_input`, `max_output` refuse the request before calling the API when an estimate exceeds the limit.
 
@@ -79,7 +79,7 @@ Also supports [multi-step pipelines](docs/guide/pipeline.md) with fail-fast and 
 
 ## Roadmap
 
-Latest: **v0.7.1** — `run_once` no longer masks adapter bugs as `:input_error`. See [CHANGELOG](CHANGELOG.md) for history.
+Latest: **v0.7.2** — terminal output labels and guides aligned with the fallback narrative; `output_schema.md` DSL bug fix. See [CHANGELOG](CHANGELOG.md) for history.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ RubyLLM::Contract.configure { |c| c.default_model = "gpt-4.1-mini" }
 
 Works with any `ruby_llm` provider (OpenAI, Anthropic, Gemini, etc).
 
+## Do I need this?
+
+Use this if LLM output affects production behaviour, money, user trust, or downstream code. You probably don't need it if you have one low-risk prompt, manually inspect every result, or only generate best-effort prose.
+
+Already using structured outputs from your provider? This gem adds business-rule validation, retry with model fallback, evals, regression gating, and test stubs on top of them — the layer that stops schema-valid-but-wrong output from reaching users. See [Why contracts?](docs/guide/why.md) for the four production failure modes the gem exists for.
+
 ## Example
 
 A Rails app takes article text extracted from a user-submitted URL and wants to show a summary card: a short TL;DR, 3–5 key takeaways, and a tone label. The output has to fit the UI (TL;DR under 200 chars) and the schema has to be strict enough to render without conditionals.
@@ -65,17 +71,20 @@ Also supports [multi-step pipelines](docs/guide/pipeline.md) with fail-fast and 
 
 ## Docs
 
-| Guide | |
-|-------|-|
-| [Getting Started](docs/guide/getting_started.md) | Features walkthrough |
-| [Eval-First](docs/guide/eval_first.md) | Datasets, baselines, A/B gates |
-| [Optimizing retry_policy](docs/guide/optimizing_retry_policy.md) | Fallback lists + production-mode cost |
-| [Best Practices](docs/guide/best_practices.md) | Validate patterns, retry-without-fallback |
-| [Output Schema](docs/guide/output_schema.md) | Full schema DSL reference + constraints |
-| [Prompt AST](docs/guide/prompt_ast.md) | Prompt DSL reference (system/rule/section/example) |
-| [Pipeline](docs/guide/pipeline.md) | Multi-step with fail-fast |
-| [Testing](docs/guide/testing.md) | Test adapter, RSpec + Minitest matchers |
-| [Migration](docs/guide/migration.md) | Adopting in existing Rails apps |
+**New here?** Read in order: this README → [Why contracts?](docs/guide/why.md) → [Getting Started](docs/guide/getting_started.md).
+
+| Guide | What it does for your app |
+|-------|---------------------------|
+| [Why contracts?](docs/guide/why.md) | Recognise the four production failures the gem exists for |
+| [Getting Started](docs/guide/getting_started.md) | Walk the full feature set on one concrete step |
+| [Adopt in an existing Rails app](docs/guide/migration.md) | Replace raw `LlmClient.call` with a contract, Before/After |
+| [Prevent silent prompt regressions](docs/guide/eval_first.md) | Evals, baselines, CI gates that block quality drift |
+| [Control retry cost and fallback behaviour](docs/guide/optimizing_retry_policy.md) | Find the cheapest viable fallback list empirically |
+| [Write validate rules that catch real bugs](docs/guide/best_practices.md) | Patterns for cross-input checks and content-quality rules |
+| [Stub LLM calls in tests](docs/guide/testing.md) | Deterministic specs, RSpec + Minitest matchers |
+| [Chain LLM calls into a pipeline](docs/guide/pipeline.md) | Multi-step with fail-fast and per-step models |
+| [Schema DSL reference](docs/guide/output_schema.md) | Every constraint, nested objects, pattern table |
+| [Prompt DSL reference](docs/guide/prompt_ast.md) | `system` / `rule` / `section` / `example` / `user` nodes |
 
 ## Roadmap
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,7 +37,6 @@ RubyLLM::Contract::Eval             # quality measurement
   ├── Eval::Recommender          # model recommendation algorithm (candidates → optimal config)
   └── Eval::Recommendation       # recommendation result (best, retry_chain, savings, to_dsl)
 
-RubyLLM::Contract::CI               # CI / Rails integration
-  ├── RakeTask                   # rake ruby_llm_contract:eval
-  └── Railtie                    # auto-loads eval files in Rails
+RubyLLM::Contract::RakeTask         # rake ruby_llm_contract:eval
+RubyLLM::Contract::Railtie          # auto-loads eval files in Rails
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,7 +6,7 @@ RubyLLM::Contract::Pipeline::Base   # optional: compose steps
 
 RubyLLM::Contract::Step::Base       # single contracted step
   ├── Step::Dsl                  # DSL macros (prompt, validate, output_schema, etc.)
-  ├── Step::RetryExecutor        # retry with model escalation
+  ├── Step::RetryExecutor        # retry with model fallback
   ├── Step::LimitChecker         # preflight cost/token checks
   ├── Prompt::AST                # structured prompt (immutable)
   │     ├── Prompt::Builder      # DSL: system, rule, example, user, section

--- a/docs/guide/best_practices.md
+++ b/docs/guide/best_practices.md
@@ -1,5 +1,7 @@
 # Best Practices
 
+> Read this when writing your first `validate` rules and you want patterns that catch real bugs instead of restating schema.
+
 Schema guarantees valid JSON structure. An LLM can still return structurally perfect JSON that is **semantically wrong**. Schema handles _shape_, validates handle _meaning_.
 
 All examples extend the `SummarizeArticle` step from the [README](../../README.md).

--- a/docs/guide/best_practices.md
+++ b/docs/guide/best_practices.md
@@ -6,6 +6,8 @@ All examples extend the `SummarizeArticle` step from the [README](../../README.m
 
 ## 1. Guard against empty / placeholder output
 
+**Why it matters:** a cheap model that answers `{"tldr": "This article discusses...", "takeaways": ["This article discusses X", ...]}` passes the schema but renders a broken UI card that tells the user nothing. The validate catches it before `Article.update!` persists it.
+
 ```ruby
 output_schema do
   string :tldr
@@ -24,6 +26,8 @@ end
 
 ## 2. Cross-validate output against input
 
+**Why it matters:** a lazy model will return the article text verbatim as the "summary", or invent takeaways about topics the article never mentions. The 2-arity form is how you catch answers that are internally consistent but unfaithful to the actual input.
+
 `validate` blocks with 2-arity `|output, input|` compare the model's answer against what was asked:
 
 ```ruby
@@ -41,6 +45,8 @@ end
 
 ## 3. Conditional logic schema can't express
 
+**Why it matters:** customer success filters on `tone == "negative"` to route angry users to a human. If the model labels an outage complaint "negative" but the takeaways are all positive-sounding, the filter runs on a label that doesn't match the content — the routing breaks silently.
+
 ```ruby
 validate("negative tone requires at least one concrete concern") do |output, _input|
   next true unless output[:tone] == "negative"
@@ -51,6 +57,8 @@ end
 A model that picks `tone: "negative"` but gives three upbeat takeaways fails this check. Schema can't catch it because each takeaway is, individually, a valid string.
 
 ## 4. Content quality
+
+**Why it matters:** a TL;DR with `## Summary` leaks markdown into a plain-text card. A one-word takeaway ("Fast.") wastes a UI slot. A leaked `{article}` placeholder reveals the prompt template to end users. All pass schema; all embarrass you in front of customers.
 
 ```ruby
 validate("no markdown headings in the TL;DR") do |o, _|
@@ -93,6 +101,8 @@ end
 The explicit `validate("tone preserved")` catches the case where the model silently rewrites the tone during a downstream transform.
 
 ## 6. Model fallback
+
+**Why it matters:** 80% of production articles are short and simple — `gpt-4.1-nano` handles them for ~$0.0001. The remaining 20% are dense, critical, or multi-topic — those need `gpt-4.1-mini` or `gpt-4.1`. Paying `gpt-4.1` rates for every call when nano is enough for most is throwing money away. Contracts tell you when nano wasn't enough, so fallback is cost-aware, not hope-based.
 
 Small models are cheap but hallucinate. Big models are accurate but expensive. Start cheap, fall back only when validates catch a failure:
 

--- a/docs/guide/best_practices.md
+++ b/docs/guide/best_practices.md
@@ -82,9 +82,9 @@ class AnalyzeStep < RubyLLM::Contract::Step::Base
 end
 ```
 
-## 6. Model escalation
+## 6. Model fallback
 
-Small models are cheap but hallucinate. Big models are accurate but expensive. Start cheap, escalate only when validates catch a failure:
+Small models are cheap but hallucinate. Big models are accurate but expensive. Start cheap, fall back only when validates catch a failure:
 
 ```ruby
 class AnalyzeCompetitor < RubyLLM::Contract::Step::Base
@@ -99,13 +99,10 @@ class AnalyzeCompetitor < RubyLLM::Contract::Step::Base
   validate("weaknesses are specific") { |o| o[:weakness_1].to_s.split.length >= 5 }
 
   retry_policy models: %w[gpt-4.1-nano gpt-4.1-mini gpt-4.1]
-  # Attempt 1: nano ($0.10/M) — handles 90% of requests
-  # Attempt 2: mini ($0.40/M) — handles 9% that nano can't
-  # Attempt 3: full ($2.00/M) — handles the last 1%
 end
 ```
 
-**Key insight:** without contracts, you can't do model escalation — you'd have no way to know if the cheap model's output is good enough. Validates are the quality gate that makes cost optimization possible.
+**Key insight:** without contracts, you can't do model fallback — you'd have no way to know if the cheap model's output is good enough. Validates are the quality gate that makes cost optimization possible. See [Optimizing retry_policy](optimizing_retry_policy.md) for how to find the cheapest viable fallback list for your step.
 
 ## Summary
 
@@ -116,4 +113,4 @@ end
 | Conditional business rules | `validate` |
 | Content quality (not empty, not template) | `validate` |
 | Data preserved across pipeline steps | `validate` + schema carry-through |
-| Cost optimization via model escalation | `retry_policy` + `validate` as quality gate |
+| Cost optimization via model fallback | `retry_policy` + `validate` as quality gate |

--- a/docs/guide/best_practices.md
+++ b/docs/guide/best_practices.md
@@ -72,8 +72,7 @@ validate("takeaways aren't single words") do |o, _|
 end
 
 validate("no template placeholders leaked") do |o, _|
-  (o[:tldr] + o[:takeaways].join(" ")).exclude?("{") rescue
-    !(o[:tldr] + o[:takeaways].join(" ")).include?("{")
+  !(o[:tldr] + o[:takeaways].join(" ")).include?("{")
 end
 ```
 

--- a/docs/guide/best_practices.md
+++ b/docs/guide/best_practices.md
@@ -1,102 +1,111 @@
 # Best Practices
 
-Schema guarantees valid JSON structure. But an LLM can return structurally perfect JSON that is **semantically wrong**. Schema handles _shape_, validates handle _meaning_.
+Schema guarantees valid JSON structure. An LLM can still return structurally perfect JSON that is **semantically wrong**. Schema handles _shape_, validates handle _meaning_.
 
-## 1. Guard against garbage output
+All examples extend the `SummarizeArticle` step from the [README](../../README.md).
+
+## 1. Guard against empty / placeholder output
 
 ```ruby
 output_schema do
-  string :decision
-  string :made_by
+  string :tldr
+  array  :takeaways, of: :string, min_items: 3, max_items: 5
+  string :tone, enum: %w[neutral positive negative analytical]
 end
 
-validate("decision must be substantive") do |o|
-  o[:decision].to_s.split.length >= 3
+validate("tldr is substantive") do |o, _|
+  o[:tldr].to_s.split.length >= 5   # at least five words
+end
+
+validate("no boilerplate takeaways") do |o, _|
+  o[:takeaways].none? { |t| t.downcase.start_with?("this article") }
 end
 ```
 
 ## 2. Cross-validate output against input
 
+`validate` blocks with 2-arity `|output, input|` compare the model's answer against what was asked:
+
 ```ruby
-validate("target language matches request") do |output, input|
-  output[:target_lang] == input[:target_lang]
+validate("tldr is shorter than the article") do |output, input|
+  output[:tldr].length < input.length / 2
 end
 
-validate("all input IDs present in output") do |output, input|
-  output[:items].map { |i| i[:id] }.sort == input[:items].map { |i| i[:id] }.sort
+validate("every takeaway appears, in spirit, in the article") do |output, input|
+  output[:takeaways].all? { |t|
+    # cheap keyword overlap heuristic
+    t.downcase.split.any? { |w| input.downcase.include?(w) && w.length > 4 }
+  }
 end
 ```
 
-## 3. Catch conditional logic
+## 3. Conditional logic schema can't express
 
 ```ruby
-output_schema do
-  string :priority, enum: %w[low medium high urgent]
-  string :summary
-end
-
-validate("urgent must be justified") do |output, input|
-  next true unless output[:priority] == "urgent"
-  body = input[:body].downcase
-  body.include?("data loss") || body.include?("security")
+validate("negative tone requires at least one concrete concern") do |output, _input|
+  next true unless output[:tone] == "negative"
+  output[:takeaways].any? { |t| t.match?(/fail|break|crash|outage|vulnerab|risk/i) }
 end
 ```
 
-## 4. Validate content quality
+A model that picks `tone: "negative"` but gives three upbeat takeaways fails this check. Schema can't catch it because each takeaway is, individually, a valid string.
+
+## 4. Content quality
 
 ```ruby
-validate("not a template response") do |o|
-  !o[:body].to_s.include?("[Name]") && !o[:body].to_s.include?("[Date]")
+validate("no markdown headings in the TL;DR") do |o, _|
+  !o[:tldr].match?(/^\#{1,6}\s/)
 end
 
-validate("minimum meaningful content") do |o|
-  o[:body].to_s.split.length >= 20
+validate("takeaways aren't single words") do |o, _|
+  o[:takeaways].all? { |t| t.split.length >= 3 }
 end
 
-validate("no markdown in plain text output") do |o|
-  !o[:comment].to_s.match?(/^\#{2,}/)
+validate("no template placeholders leaked") do |o, _|
+  (o[:tldr] + o[:takeaways].join(" ")).exclude?("{") rescue
+    !(o[:tldr] + o[:takeaways].join(" ")).include?("{")
 end
 ```
 
 ## 5. Pipeline: preserve data between steps
 
-In a pipeline, each step only sees the previous step's output. If step 3 needs data from step 1, step 2 must carry it through.
+In a pipeline, each step only sees the previous step's output. If a later step needs original article metadata, an intermediate step must carry it through. Suppose a pipeline `SummarizeArticle → GenerateHashtags`, where `GenerateHashtags` needs the `tone` from the summary:
 
 ```ruby
-class AnalyzeStep < RubyLLM::Contract::Step::Base
+class GenerateHashtags < RubyLLM::Contract::Step::Base
+  input_type Hash
+
   output_schema do
-    # Carry through from step 1
-    string :decision
-    string :decision_by
-    # Add new analysis fields
-    string :status, enum: %w[clear ambiguous]
-    string :issue
+    # Carry through the fields a downstream step (or the caller) might need
+    string :tone, enum: %w[neutral positive negative analytical]
+    array  :hashtags, of: :string, min_items: 2, max_items: 5
   end
 
   prompt do
-    rule "Pass through decision and decision_by unchanged."
-    user "{input}"
+    rule "Preserve the tone label from the input unchanged."
+    user "Summary: {tldr}\nTone: {tone}\nTakeaways: {takeaways}"
   end
 
-  validate("decision preserved") { |o| !o[:decision].to_s.strip.empty? }
+  validate("tone preserved") { |o, input| o[:tone] == input[:tone] }
 end
 ```
+
+The explicit `validate("tone preserved")` catches the case where the model silently rewrites the tone during a downstream transform.
 
 ## 6. Model fallback
 
 Small models are cheap but hallucinate. Big models are accurate but expensive. Start cheap, fall back only when validates catch a failure:
 
 ```ruby
-class AnalyzeCompetitor < RubyLLM::Contract::Step::Base
+class SummarizeArticle < RubyLLM::Contract::Step::Base
   output_schema do
-    string :company_name
-    string :pricing_model, enum: %w[freemium subscription one_time usage_based]
-    string :strength_1
-    string :weakness_1
+    string :tldr
+    array  :takeaways, of: :string, min_items: 3, max_items: 5
+    string :tone, enum: %w[neutral positive negative analytical]
   end
 
-  validate("strengths are specific") { |o| o[:strength_1].to_s.split.length >= 5 }
-  validate("weaknesses are specific") { |o| o[:weakness_1].to_s.split.length >= 5 }
+  validate("TL;DR fits the card")  { |o, _| o[:tldr].length <= 200 }
+  validate("takeaways are unique") { |o, _| o[:takeaways].uniq.size == o[:takeaways].size }
 
   retry_policy models: %w[gpt-4.1-nano gpt-4.1-mini gpt-4.1]
 end
@@ -107,9 +116,9 @@ end
 ## Summary
 
 | What to validate | Use |
-|-----------------|-----|
+|---|---|
 | Field types, enums, ranges, required fields | `output_schema` |
-| Output makes sense given the input | `validate` (2-arity) |
+| Output makes sense given the input | `validate` (2-arity `\|output, input\|`) |
 | Conditional business rules | `validate` |
 | Content quality (not empty, not template) | `validate` |
 | Data preserved across pipeline steps | `validate` + schema carry-through |

--- a/docs/guide/eval_first.md
+++ b/docs/guide/eval_first.md
@@ -10,259 +10,147 @@ If you change prompts by feel, you ship regressions by feel.
 4. Re-run the same eval.
 5. Merge only if the eval says quality improved or stayed safe.
 
-That is the practical version of `eval-first`.
-
-## Core Rule
+## Core rule
 
 **Do not start with the prompt. Start with the eval.**
 
-In this gem, that means:
+Using the `SummarizeArticle` step from the [README](../../README.md):
 
 ```ruby
-ClassifyTicket.define_eval("regression") do
-  add_case "billing dispute",
-           input: "I was charged twice this month",
-           expected: { priority: "high", category: "billing" }
+SummarizeArticle.define_eval("regression") do
+  add_case "ruby release",
+           input: "Ruby 3.4 shipped with frozen string literals...",
+           expected: { tone: "analytical" }  # partial match
 
-  add_case "outage",
-           input: "Database is down for all customers",
-           expected: { priority: "urgent", category: "technical" }
+  add_case "critical review",
+           input: "Mesh networking hardware failed under load...",
+           expected: { tone: "negative" }
 end
 ```
 
-Then and only then:
-- add or change `system`
-- tighten `rule`
-- add `example`
-- change `validate`
-- compare prompt versions
+Only after the eval exists, touch: `system`, `rule`, `example`, `validate`, prompt versions.
 
-## The Right Mental Model
+## Three eval kinds
 
-Use the gem in three layers:
-
-### 1. `smoke`
-
-Fast, local, often offline.
-
-Purpose:
-- verify that the step still parses
-- verify schema and validates
-- catch obvious contract breakage
+### 1. `smoke` — wiring check, offline
 
 ```ruby
-ClassifyTicket.define_eval("smoke") do
-  default_input "My invoice is wrong"
-  sample_response({ priority: "high", category: "billing" })
+SummarizeArticle.define_eval("smoke") do
+  default_input "Ruby 3.4 shipped with frozen string literals..."
+  sample_response({ tldr: "...", takeaways: [...], tone: "analytical" })
 end
 ```
 
-`sample_response` is good here.
+`sample_response` returns canned data. Zero API calls. Verifies schema + validates parse and the step wiring is intact. **Not a quality signal.**
 
-It is **not** your main quality signal.
+### 2. `regression` — real quality measurement
 
-### 2. `regression`
+Represent real traffic and known failures. Good sources: production logs, bad completions, incidents, QA edge cases, cases a human had to correct.
 
-This is your real eval-first dataset.
+Every production failure becomes `add_case`. That's the flywheel.
 
-Purpose:
-- represent real user traffic
-- capture known failures and expensive mistakes
-- gate merges and prompt changes
+### 3. `ab` — prompt iteration
 
-Good sources:
-- support tickets
-- bad completions from logs
-- incidents
-- edge cases found in QA
-- cases where a human had to correct the output
-
-Every time the model fails in production, the default response should be:
-
-`add_case`, then fix.
-
-### 3. `ab`
-
-Prompt iteration.
-
-Purpose:
-- compare old prompt vs new prompt on the same dataset
-- block regressions before rollout
+Compare two prompt versions on the same eval:
 
 ```ruby
-diff = ClassifyTicketV2.compare_with(
-  ClassifyTicketV1,
+diff = SummarizeArticleV2.compare_with(
+  SummarizeArticleV1,
   eval: "regression",
   model: "gpt-4.1-mini"
 )
 
-diff.safe_to_switch?
+diff.safe_to_switch?  # => true if no cases regressed
 ```
 
-This is the cleanest `eval-first` move in the gem: same eval, same cases, two prompt versions.
+This is the cleanest eval-first move: same eval, same cases, two prompt versions, one answer.
 
-## What Counts As Eval-First In This Gem
+## What counts as eval-first
 
-### Good
+**Good** — eval exists before the prompt change:
 
 ```ruby
-ClassifyTicket.define_eval("regression") do
-  add_case "refund", input: "Refund me", expected: { category: "billing" }
+SummarizeArticle.define_eval("regression") do
+  add_case "short article", input: "...", expected: { tone: "neutral" }
 end
 
-# Prompt changes happen after the eval exists
-diff = NewPrompt.compare_with(OldPrompt, eval: "regression", model: "gpt-4.1-mini")
+# Prompt iteration happens afterward
+diff = SummarizeArticleV2.compare_with(SummarizeArticleV1, eval: "regression", model: "gpt-4.1-mini")
 ```
 
-### Bad
+**Bad**:
 
 ```ruby
 # Tweak prompt for an hour
 # Maybe add an example
 # Maybe tighten a rule
-# Then manually eyeball one or two responses
+# Then eyeball one or two responses
 ```
 
-That is not eval-first. That is prompt guessing.
+That's prompt guessing, not eval-first.
 
-## `sample_response`: Useful, But Not The Main Thing
+## `sample_response`: useful, but not the main thing
 
-`sample_response` is excellent for:
-- offline smoke tests
-- local development
-- testing evaluator wiring
-- verifying schema + validate behavior with zero API calls
+Good for: offline smoke tests, local development, testing evaluator wiring, checking schema + validate behavior with zero API calls.
 
-It is **not** enough for real prompt decisions.
+Not enough for real prompt decisions. For those:
 
-For real eval-first work:
-- use `run_eval(..., context: { model: "..." })`
-- or pass an explicit adapter
+- `run_eval(..., context: { model: "..." })` with a real model, or pass an explicit adapter.
+- `compare_with(...)` for prompt A/B.
 
-And for prompt A/B:
-- use `compare_with`
-- with a real `model:` or explicit adapters
+`compare_with` intentionally ignores `sample_response` — canned data would make both sides look the same.
 
-`compare_with` intentionally ignores `sample_response`, because canned data would make both sides look the same.
+## Team workflow
 
-## The Minimal Team Workflow
+1. **Build one eval that matters** — 10–30 cases representing real mistakes and important business paths.
+2. **Gate CI** — `pass_eval("regression").with_context(model: "...").with_minimum_score(0.8)`. See [Getting Started](getting_started.md) for the full matcher chain.
+3. **Save a baseline** — `report.save_baseline!` makes quality drift visible.
+4. **Change prompts only through comparison** — `pass_eval(...).compared_with(SummarizeArticleV1)` in CI so any regression blocks the merge.
+5. **Feed production failures back** — every miss in prod → new `add_case`, then fix. The eval gets stronger over time.
 
-### Step 1. Build one eval that matters
+## Few-shot examples fit naturally
 
-Start with 10 to 30 cases that represent real mistakes and important business paths.
+Adding `example input: ..., output: ...` inside the prompt is still a prompt change. The eval-first way:
 
-```ruby
-ClassifyTicket.define_eval("regression") do
-  add_case "invoice", input: "Invoice is wrong", expected: { category: "billing" }
-  add_case "feature", input: "Please add dark mode", expected: { priority: "low" }
-  add_case "outage", input: "Everything is down", expected: { priority: "urgent" }
-end
-```
+1. Add examples to the prompt.
+2. Rerun the existing regression eval.
+3. `compare_with` against the old prompt.
 
-### Step 2. Gate it in CI
+Few-shot isn't the proof. The eval is.
 
-```ruby
-expect(ClassifyTicket).to pass_eval("regression")
-  .with_context(model: "gpt-4.1-mini")
-  .with_minimum_score(0.8)
-```
+## Model selection comes after prompt stability
 
-Now prompt changes stop being opinion-based.
+Don't optimize cost before you stabilize quality:
 
-### Step 3. Save a baseline
+1. Build `regression`.
+2. Improve the prompt with `compare_with`.
+3. Lock quality in CI.
+4. Then run `compare_models` (see [Optimizing retry_policy](optimizing_retry_policy.md)).
 
 ```ruby
-report = ClassifyTicket.run_eval("regression", context: { model: "gpt-4.1-mini" })
-report.save_baseline!(model: "gpt-4.1-mini")
-```
-
-This makes quality drift visible.
-
-### Step 4. Change prompts only through comparison
-
-```ruby
-expect(ClassifyTicketV2).to pass_eval("regression")
-  .with_context(model: "gpt-4.1-mini")
-  .compared_with(ClassifyTicketV1)
-  .with_minimum_score(0.8)
-```
-
-If the new prompt regresses, the change does not merge.
-
-### Step 5. Add every production failure back into the eval
-
-This is the flywheel:
-
-- failure in prod
-- add a case
-- improve prompt
-- rerun eval
-- lock it with CI
-
-That is how the eval gets stronger over time.
-
-## Few-Shot Examples Fit Naturally
-
-If you add:
-
-```ruby
-example input: "My invoice is wrong", output: '{"priority":"high","category":"billing"}'
-```
-
-that is still just a prompt change.
-
-The eval-first way to use few-shot is:
-
-1. add examples to the prompt
-2. rerun the existing regression eval
-3. compare against the old prompt with `compare_with`
-
-Few-shot is not the proof.
-The eval is the proof.
-
-## Model Selection Comes After Prompt Stability
-
-Do not optimize model cost before you stabilize prompt quality.
-
-Recommended order:
-
-1. Build `regression`
-2. Improve prompt with `compare_with`
-3. Lock quality in CI
-4. Then run `compare_models`
-
-```ruby
-comparison = ClassifyTicket.compare_models(
+comparison = SummarizeArticle.compare_models(
   "regression",
-  models: %w[gpt-4.1-nano gpt-4.1-mini gpt-4.1]
+  candidates: [{ model: "gpt-4.1-nano" }, { model: "gpt-4.1-mini" }, { model: "gpt-4.1" }]
 )
 
 comparison.best_for(min_score: 0.95)
 ```
 
-This keeps cost optimization downstream from quality.
+## Strong defaults for teams
 
-## Strong Defaults For Teams
+- `smoke` uses `sample_response`.
+- `regression` uses real model calls.
+- Every prompt change uses `compare_with`.
+- Every merge runs `pass_eval`.
+- Every production failure becomes a new `add_case`.
 
-If you want one simple standard:
-
-- `smoke` uses `sample_response`
-- `regression` uses real model calls
-- every prompt change uses `compare_with`
-- every merge runs `pass_eval`
-- every production failure becomes a new `add_case`
-
-That is enough to make the gem work in a real eval-first loop.
-
-## Short Version
-
-Use the gem like this:
+## Short version
 
 1. Write `define_eval` before touching the prompt.
 2. Treat `sample_response` as smoke only.
 3. Use `run_eval("name", context: { model: "..." })` for real quality measurement.
 4. Use `compare_with` for every serious prompt change.
 5. Gate merges with `pass_eval`.
-6. Feed every production miss back into the eval dataset.
+6. Feed every production miss back into the dataset.
 
-If you do that consistently, prompts stop being vibes and start being engineering.
+Prompts stop being vibes and start being engineering.

--- a/docs/guide/eval_first.md
+++ b/docs/guide/eval_first.md
@@ -2,13 +2,17 @@
 
 If you change prompts by feel, you ship regressions by feel.
 
+Concrete scenario: `SummarizeArticle` has been running in production for two weeks. Customer success notices that complaints about service outages keep getting `tone: "analytical"` instead of `"negative"` — so their "critical feedback" filter silently misses angry users. Someone tweaks the system prompt to emphasise negative sentiment. It fixes the outage article but now three neutral product-update articles get misclassified as `"negative"`. You find out from a Slack thread.
+
+That is the cost of prompt-by-feel. Evals are how you stop it.
+
 `ruby_llm-contract` works best when you treat evals as the source of truth:
 
-1. Capture real failures from production.
-2. Turn them into eval cases.
+1. Capture real failures from production (the outage article, verbatim).
+2. Turn them into eval cases (`add_case "service outage complaint"`).
 3. Change the prompt.
-4. Re-run the same eval.
-5. Merge only if the eval says quality improved or stayed safe.
+4. Re-run the same eval — plus all previously-passing cases.
+5. Merge only if the eval says quality improved or stayed safe on every case.
 
 ## Core rule
 

--- a/docs/guide/eval_first.md
+++ b/docs/guide/eval_first.md
@@ -100,6 +100,30 @@ Not enough for real prompt decisions. For those:
 
 `compare_with` intentionally ignores `sample_response` — canned data would make both sides look the same.
 
+## Parallel eval runs
+
+For larger datasets, `run_eval` accepts a `concurrency:` argument — cases run in parallel using a thread pool:
+
+```ruby
+report = SummarizeArticle.run_eval("regression",
+  context: { model: "gpt-4.1-mini" },
+  concurrency: 8)
+```
+
+Same accepted by `compare_models` and `optimize_retry_policy`. Thread count is a ceiling — dataset order of results is preserved. Keep it low enough to respect the provider's rate limits.
+
+## Budgeting an eval before you run it
+
+`estimate_eval_cost` gives you a cost projection without calling the LLM:
+
+```ruby
+SummarizeArticle.estimate_eval_cost("regression",
+  models: %w[gpt-4.1-nano gpt-4.1-mini gpt-4.1])
+# => { "gpt-4.1-nano" => 0.00041, "gpt-4.1-mini" => 0.0018, "gpt-4.1" => 0.0092 }
+```
+
+Use it in CI to decide which models are worth running regression on, or to cap worst-case spend per build.
+
 ## Team workflow
 
 1. **Build one eval that matters** — 10–30 cases representing real mistakes and important business paths.

--- a/docs/guide/eval_first.md
+++ b/docs/guide/eval_first.md
@@ -37,7 +37,7 @@ Only after the eval exists, touch: `system`, `rule`, `example`, `validate`, prom
 ```ruby
 SummarizeArticle.define_eval("smoke") do
   default_input "Ruby 3.4 shipped with frozen string literals..."
-  sample_response({ tldr: "...", takeaways: [...], tone: "analytical" })
+  sample_response({ tldr: "...", takeaways: ["point one", "point two", "point three"], tone: "analytical" })
 end
 ```
 

--- a/docs/guide/eval_first.md
+++ b/docs/guide/eval_first.md
@@ -1,5 +1,7 @@
 # Eval-First
 
+> Read this when you need to prevent silent prompt regressions in CI. Skip if your LLM output is evaluated only by humans and never gated in an automated pipeline.
+
 If you change prompts by feel, you ship regressions by feel.
 
 Concrete scenario: `SummarizeArticle` has been running in production for two weeks. Customer success notices that complaints about service outages keep getting `tone: "analytical"` instead of `"negative"` — so their "critical feedback" filter silently misses angry users. Someone tweaks the system prompt to emphasise negative sentiment. It fixes the outage article but now three neutral product-update articles get misclassified as `"negative"`. You find out from a Slack thread.

--- a/docs/guide/getting_started.md
+++ b/docs/guide/getting_started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-The README shows a minimal `SummarizeArticle` step. This guide walks through the features you reach for as production requirements grow: budget caps so runaway inputs don't drain your OpenAI account, evals so you catch regressions in CI, and CI gating so a merge that lowers accuracy gets blocked.
+The README shows a minimal `SummarizeArticle` step. This guide walks through the features you reach for as production requirements grow: budget caps so runaway inputs don't drain your LLM provider budget, evals so you catch regressions in CI, and CI gating so a merge that lowers accuracy gets blocked.
 
 ## The walkthrough
 

--- a/docs/guide/getting_started.md
+++ b/docs/guide/getting_started.md
@@ -47,7 +47,7 @@ result = SummarizeArticle.run(article_text)
 result.status           # => :ok
 result.parsed_output    # => { tldr: "...", takeaways: [...], tone: "analytical" }
 result.trace[:model]    # => "gpt-4.1-mini"  (first model that passed)
-result.trace[:cost]     # => 0.000042
+result.trace[:cost]     # => 0.00052  (sum of all attempts)
 result.trace[:attempts]
 # => [
 #   { attempt: 1, model: "gpt-4.1-nano", status: :validation_failed, cost: 0.00010, latency_ms: 45, ... },

--- a/docs/guide/getting_started.md
+++ b/docs/guide/getting_started.md
@@ -163,7 +163,7 @@ SummarizeArticle.estimate_eval_cost("regression",
 # => { "gpt-4.1-nano" => 0.00041, "gpt-4.1-mini" => 0.0018, "gpt-4.1" => 0.0092 }
 ```
 
-Returns `nil` for a single call (or `0.0` summed) when pricing isn't registered — same failure mode as `max_cost`.
+`estimate_cost` returns `nil` when pricing isn't registered. `estimate_eval_cost` silently treats unknown-pricing cases as `$0.00` and sums the rest — it does **not** fail closed the way `max_cost` does. Treat its output as a floor, not a guarantee; register pricing via `CostCalculator.register_model` before relying on it for budget decisions.
 
 ## `output_schema` vs `with_schema`
 

--- a/docs/guide/getting_started.md
+++ b/docs/guide/getting_started.md
@@ -1,222 +1,152 @@
 # Getting Started
 
-## When you need more
+The README shows a minimal `SummarizeArticle` step. This guide walks through the features you reach for as production requirements grow: budget caps so runaway inputs don't drain your OpenAI account, evals so you catch regressions in CI, and CI gating so a merge that lowers accuracy gets blocked.
 
-The heredoc prompt is the starting point. Add features as your production needs grow:
+## The walkthrough
+
+Start with the README example, then add features one layer at a time. Each is optional — use what you need.
 
 ```ruby
-class ClassifyTicket < RubyLLM::Contract::Step::Base
-  # STEP 1: You already have this — your prompt as a heredoc
+class SummarizeArticle < RubyLLM::Contract::Step::Base
+  # 1. Prompt (required)
   prompt <<~PROMPT
-    Classify this support ticket by priority and category.
-    Return JSON with priority, category, and confidence fields.
+    Summarize this article for a UI card. Return a short TL;DR,
+    3 to 5 key takeaways, and a tone label.
 
     {input}
   PROMPT
 
-  # STEP 2: Add schema — sent to the LLM provider, which forces the model
-  # to return this exact JSON structure (replaces manual type validates)
+  # 2. Schema — sent to the provider via with_schema, validated client-side
   output_schema do
-    string :priority, enum: %w[low medium high urgent]
-    string :category, enum: %w[billing technical feature other]
-    number :confidence, minimum: 0.0, maximum: 1.0
+    string :tldr
+    array  :takeaways, of: :string, min_items: 3, max_items: 5
+    string :tone, enum: %w[neutral positive negative analytical]
   end
 
-  # STEP 3: Add business logic that schema can't express
-  validate("high confidence") { |o| o[:confidence] > 0.5 }
+  # 3. Business rules — things JSON Schema cannot express
+  validate("TL;DR fits the card")  { |o, _| o[:tldr].length <= 200 }
+  validate("takeaways are unique") { |o, _| o[:takeaways].uniq.size == o[:takeaways].size }
 
-  # STEP 4: Start with a cheap model, auto-escalate when contract fails
+  # 4. Retry with model fallback on validation_failed / parse_error
   retry_policy models: %w[gpt-4.1-nano gpt-4.1-mini gpt-4.1]
 
-  # STEP 5: Refuse before calling the LLM if input is too large or expensive
+  # 5. Refuse before calling the LLM if input is too large or estimated cost exceeds the cap
   max_input  2_000
   max_output 4_000
   max_cost   0.01
 end
 ```
 
-Each step is optional. Here's what each layer catches in production:
+## Validation and retry behavior
 
-**Validation catches wrong answers** (and retry auto-escalates to fix them):
-```ruby
-result = ClassifyTicket.run("Server is on fire, data is gone!")
-result.status            # => :validation_failed
-result.validation_errors # => ["high confidence"]
-result.parsed_output     # => {priority: "low", category: "billing", confidence: 0.2}
-# ^ LLM said "low priority" for a data loss incident. validate caught it.
-# With retry_policy, the gem automatically retries with a smarter model.
-# Without retry_policy, you get the failed result and decide what to do.
-```
+When the cheap model returns output that fails a `validate` block or can't be parsed, retry falls back to the next model in `models:` and tries again.
 
-**Retry with model escalation saves money:**
 ```ruby
-result = ClassifyTicket.run("I need help with billing")
+result = SummarizeArticle.run(article_text)
+
+result.status           # => :ok
+result.parsed_output    # => { tldr: "...", takeaways: [...], tone: "analytical" }
+result.trace[:model]    # => "gpt-4.1-mini"  (first model that passed)
+result.trace[:cost]     # => 0.000042
 result.trace[:attempts]
-# => [{attempt: 1, model: "gpt-4.1-nano",  status: :validation_failed},  # $0.0001
-#     {attempt: 2, model: "gpt-4.1-mini",  status: :ok}]                 # $0.0004
-# Nano hallucinated, mini got it right. Never called full ($0.002).
-# 90% of requests succeed on nano. You only pay more when you have to.
+# => [
+#   { attempt: 1, model: "gpt-4.1-nano", status: :validation_failed, cost: 0.00010, latency_ms: 45, ... },
+#   { attempt: 2, model: "gpt-4.1-mini", status: :ok,                cost: 0.00042, latency_ms: 92, ... }
+# ]
 ```
 
-**Model priority:** `retry_policy models: %w[nano mini full]` tries models left to right. First model is always tried first. `context: { model: "..." }` is ignored when `retry_policy` is set — the policy controls model selection. Without `retry_policy`, the model comes from `context[:model]` or `default_model`.
+If the whole chain exhausts, `result.status` is the status of the last attempt (`:validation_failed` or `:parse_error`) and `result.parsed_output` is the last attempt's output. The caller decides what to do — ship it anyway, fall back to a template, or raise.
 
-**Reasoning effort:** For models that support it, control how much the model "thinks" before answering:
+## Evals and CI gates
+
+An eval is a named scenario you can run to verify the step still works. `sample_response` makes it offline — zero API calls — so CI can run it on every merge without burning budget.
+
 ```ruby
-result = ClassifyTicket.run(ticket, context: { reasoning_effort: "low" })
-# "low" / "medium" / "high" — passed to the provider via with_params
+SummarizeArticle.define_eval("smoke") do
+  default_input <<~ARTICLE
+    Ruby 3.4 ships with frozen string literals on by default, measurable YJIT
+    speedups on Rails workloads, and tightened Warning.warn category filtering.
+    The release notes also mention several parser fixes and faster keyword
+    argument handling.
+  ARTICLE
+
+  sample_response({
+    tldr: "Ruby 3.4 brings frozen string literals by default, YJIT speedups, and parser fixes.",
+    takeaways: [
+      "Frozen string literals are the default",
+      "YJIT adds measurable speedups on Rails workloads",
+      "Warning.warn category filtering is tighter"
+    ],
+    tone: "analytical"
+  })
+end
+
+report = SummarizeArticle.run_eval("smoke")
+report.passed?  # => true — schema + validates pass on the canned response
+report.score    # => 1.0
+report.print_summary
 ```
 
-**Limits prevent runaway costs:**
+For real regression testing, define cases with expected output (online — calls the LLM):
+
 ```ruby
-result = ClassifyTicket.run(giant_10mb_document)
+SummarizeArticle.define_eval("regression") do
+  add_case "ruby release",
+           input: "Ruby 3.4 was released...",
+           expected: { tone: "analytical" }  # partial match
+
+  add_case "critical review",
+           input: "The new mesh networking hardware failed under load...",
+           expected: { tone: "negative" }
+end
+```
+
+Gate CI on score and cost thresholds:
+
+```ruby
+# RSpec — blocks merge if accuracy drops or cost spikes
+expect(SummarizeArticle).to pass_eval("regression")
+  .with_minimum_score(0.8)
+  .with_maximum_cost(0.01)
+```
+
+Save a baseline once, then block regressions automatically:
+
+```ruby
+report = SummarizeArticle.run_eval("regression")
+report.save_baseline!
+
+# In CI:
+expect(SummarizeArticle).to pass_eval("regression").without_regressions
+```
+
+`without_regressions` fails the build only if a previously-passing case now fails — a new model version, a prompt tweak, or an upstream change that silently lowered quality.
+
+## Budget caps
+
+`max_input`, `max_output`, and `max_cost` are preflight checks — the LLM is never called if an estimate exceeds the limit. Zero tokens spent, zero cost.
+
+```ruby
+result = SummarizeArticle.run(giant_10mb_document)
 result.status            # => :limit_exceeded
 result.validation_errors # => ["Input token limit exceeded: estimated 32000 tokens, max 2000"]
-# LLM was never called. Zero tokens spent. Zero cost.
 ```
 
-`max_cost` refuses the call when model pricing is unknown (fail closed). Register pricing for custom or fine-tuned models:
+`max_cost` fails closed when the model's pricing isn't known — register custom or fine-tuned models explicitly:
 
 ```ruby
 RubyLLM::Contract::CostCalculator.register_model("ft:gpt-4o-custom",
   input_per_1m: 3.0, output_per_1m: 6.0)
 ```
 
-**Eval verifies your contract — offline or online:**
+## `output_schema` vs `with_schema`
 
-Offline mode (zero API calls) — uses a canned response to verify schema + validates:
-```ruby
-ClassifyTicket.define_eval("smoke") do
-  default_input "My invoice is wrong"
-  sample_response({ priority: "high", category: "billing", confidence: 0.92 })
-end
+`with_schema` in `ruby_llm` tells the provider to force a specific JSON structure. `output_schema` in this gem does the same thing (calls `with_schema` under the hood) **plus** validates the response client-side. Cheaper models sometimes ignore schema constraints — `with_schema` is a request; `output_schema` is a request plus verification.
 
-report = ClassifyTicket.run_eval("smoke")
-report.passed?  # => true — schema + validates pass on sample data
-report.score    # => 1.0
-```
+## See also
 
-Online mode (v0.2) — define cases with expected output, then compare models:
-```ruby
-ClassifyTicket.define_eval("regression") do
-  add_case "billing complaint",
-           input: "My invoice is wrong",
-           expected: { priority: "high", category: "billing" }  # partial match
-
-  add_case "urgent outage",
-           input: "Server is down, customers affected",
-           expected: { priority: "urgent" }
-end
-
-# Run against one model
-report = ClassifyTicket.run_eval("regression")
-report.score  # => 1.0
-
-# Compare models — find the cheapest one that passes
-comparison = ClassifyTicket.compare_models("regression",
-                                           models: %w[gpt-4.1-nano gpt-4.1-mini gpt-4.1])
-comparison.print_summary
-#   Model                      Score       Cost  Avg Latency
-#   ---------------------------------------------------------
-#   gpt-4.1-nano                0.50    $0.0001         48ms
-#   gpt-4.1-mini                1.00    $0.0004         92ms
-#   gpt-4.1                     1.00    $0.0021        210ms
-#
-#   Cheapest at 100%: gpt-4.1-mini
-```
-
-In CI — gate on score threshold and cost:
-```ruby
-# rspec
-expect(ClassifyTicket).to pass_eval("regression")
-  .with_minimum_score(0.8)
-  .with_maximum_cost(0.01)
-```
-
-## Structured Prompts
-
-When you need system instructions, rules, or few-shot examples, upgrade from heredoc to block:
-
-```ruby
-class ClassifyIntent < RubyLLM::Contract::Step::Base
-  output_schema do
-    string :intent, enum: %w[sales support billing]
-    number :confidence, minimum: 0.0, maximum: 1.0
-  end
-
-  prompt do
-    system "Classify the user's intent."
-    rule   "Return JSON only."
-    example input: "I want to buy", output: '{"intent":"sales","confidence":0.95}'
-    user   "{input}"
-  end
-
-  validate("high confidence") { |o| o[:confidence] > 0.5 }
-  retry_policy models: %w[gpt-4.1-nano gpt-4.1-mini gpt-4.1]
-end
-```
-
-## Dynamic Prompts
-
-When your prompt needs data from Rails objects — conditional sections, formatted lists, runtime context — the block receives `|input|`:
-
-```ruby
-class ClassifyThreads < RubyLLM::Contract::Step::Base
-  input_type Hash
-
-  prompt do |input|
-    system "You classify Reddit threads for #{input[:url]}."
-    section "PRODUCT", input[:product_context]
-    section "PAGES", input[:pages].map { |p| "- #{p[:title]}" }.join("\n") if input[:pages]&.any?
-    user input[:threads].to_json
-  end
-
-  validate("all classified") do |output, input|
-    output[:threads].map { |t| t[:id] }.sort == input[:thread_ids].sort
-  end
-
-  retry_policy models: %w[gpt-4.1-mini gpt-4.1-mini gpt-4.1]
-end
-```
-
-| Your prompt needs | Use |
-|-------------------|-----|
-| Static text, one variable | `prompt "Classify: {input}"` |
-| Multiple messages, static | `prompt do; system "..."; user "{input}"; end` |
-| Dynamic data from objects | `prompt do \|input\|; section "X", input[:data]; end` |
-
-## Already using ruby_llm?
-
-You might think: "I already have `RubyLLM.chat`, `with_schema`, and my own retry loop. Why do I need this?"
-
-**What you write today (per call site):**
-```ruby
-3.times do |attempt|
-  response = RubyLLM.chat(model: "gpt-4.1-mini").ask(prompt)
-  parsed = JSON.parse(response.content)
-  break if parsed["priority"].in?(%w[low medium high urgent])
-rescue JSON::ParserError
-  next
-end
-```
-Multiply by 7 call sites = ~500 lines of boilerplate. Each with its own retry logic, error handling, and validation.
-
-**What you write with this gem:**
-```ruby
-class ClassifyTicket < RubyLLM::Contract::Step::Base
-  prompt "Classify this ticket by priority.\n\n{input}"
-  validate("valid priority") { |o| %w[low medium high urgent].include?(o[:priority]) }
-  retry_policy models: %w[gpt-4.1-nano gpt-4.1-mini gpt-4.1]
-end
-```
-
-**Three things you can't easily build yourself:**
-
-1. **Model escalation with quality gate.** Start every request on nano ($0.10/M tokens). When `validate` catches a bad answer, auto-retry on mini ($0.40/M), then full ($2.00/M). 90% of requests succeed on nano. At 10k requests/month: ~$40 instead of ~$200.
-
-2. **Eval that matters.** Offline smoke tests with `sample_response` (zero API calls). Online regression with `add_case` + partial matching. `compare_models` to find the cheapest model that passes. Cost tracking per eval run. CI gating with `with_minimum_score(0.8)` and `with_maximum_cost(0.01)`. No other Ruby gem does this.
-
-3. **Defensive parsing.** LLM wraps JSON in ` ```json ``` `? Stripped. UTF-8 BOM? Stripped. Prose around JSON? Extracted. `null` response? Caught. 14 edge cases in the parser.
-
-**`output_schema` vs `with_schema`:**
-
-`with_schema` in ruby_llm tells the provider to force a specific JSON structure. `output_schema` in this gem does the **same thing** (calls `with_schema` under the hood) **plus** validates the response client-side. Why both? Because cheaper models sometimes ignore schema constraints. `with_schema` is a request; `output_schema` is a request + verification.
+- [Prompt AST](prompt_ast.md) — prompt DSL variants: `system`, `rule`, `section`, `example`, `user`, and dynamic prompts with `|input|`.
+- [Eval-First](eval_first.md) — datasets, baselines, A/B gates, the workflow that makes the above evals useful.
+- [Optimizing retry_policy](optimizing_retry_policy.md) — find the cheapest viable fallback list with `compare_models` and `optimize_retry_policy`.
+- [Testing](testing.md) — test adapter, `stub_step`, full RSpec + Minitest matcher reference.
+- [Output Schema](output_schema.md) — nested objects in arrays, constraints, pattern reference.

--- a/docs/guide/getting_started.md
+++ b/docs/guide/getting_started.md
@@ -1,5 +1,7 @@
 # Getting Started
 
+> Read this to walk through every feature on one concrete step for the first time.
+
 The README shows a minimal `SummarizeArticle` step. This guide walks through the features you reach for as production requirements grow: budget caps so runaway inputs don't drain your LLM provider budget, evals so you catch regressions in CI, and CI gating so a merge that lowers accuracy gets blocked.
 
 ## The walkthrough

--- a/docs/guide/getting_started.md
+++ b/docs/guide/getting_started.md
@@ -139,6 +139,30 @@ RubyLLM::Contract::CostCalculator.register_model("ft:gpt-4o-custom",
   input_per_1m: 3.0, output_per_1m: 6.0)
 ```
 
+Or opt into a soft warning instead of a refusal when pricing is missing:
+
+```ruby
+max_cost 0.01, on_unknown_pricing: :warn
+```
+
+Default is `:refuse`. Use `:warn` only when you accept running without a cost ceiling (fine-tuned models you trust, private endpoints).
+
+### Preflight cost estimates
+
+Check what a call is likely to cost before invoking it:
+
+```ruby
+SummarizeArticle.estimate_cost(input: article_text)
+# => { model: "gpt-4.1-mini", input_tokens: 812, output_tokens_estimate: 4000, estimated_cost: 0.00243 }
+
+# Estimate what a full eval would cost across candidate models
+SummarizeArticle.estimate_eval_cost("regression",
+  models: %w[gpt-4.1-nano gpt-4.1-mini gpt-4.1])
+# => { "gpt-4.1-nano" => 0.00041, "gpt-4.1-mini" => 0.0018, "gpt-4.1" => 0.0092 }
+```
+
+Returns `nil` for a single call (or `0.0` summed) when pricing isn't registered — same failure mode as `max_cost`.
+
 ## `output_schema` vs `with_schema`
 
 `with_schema` in `ruby_llm` tells the provider to force a specific JSON structure. `output_schema` in this gem does the same thing (calls `with_schema` under the hood) **plus** validates the response client-side. Cheaper models sometimes ignore schema constraints — `with_schema` is a request; `output_schema` is a request plus verification.

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -1,6 +1,6 @@
 # Migration Guide
 
-How to adopt ruby_llm-contract in an existing Rails app.
+How to adopt `ruby_llm-contract` in an existing Rails app. Examples use `SummarizeArticle` — the flagship step from the [README](../../README.md) — but the pattern applies to any single-input / structured-output service.
 
 ## Step 1: Start with the simplest service
 
@@ -9,32 +9,35 @@ Pick the LLM service with: single input → JSON output → DB save. Don't start
 ## Step 2: Define the contract
 
 **Before — raw HTTP:**
+
 ```ruby
-class ClassifyService
-  def call(text)
-    response = LlmClient.new(model: "gpt-4o-mini").call(prompt(text))
+class ArticleSummaryService
+  def call(article_text)
+    response = LlmClient.new(model: "gpt-4o-mini").call(prompt(article_text))
     JSON.parse(response[:content], symbolize_names: true)
   end
 end
 ```
 
 **After — contract:**
+
 ```ruby
-class ClassifyTicket < RubyLLM::Contract::Step::Base
+class SummarizeArticle < RubyLLM::Contract::Step::Base
   model "gpt-4.1-mini"
 
   prompt do
-    system "You classify support tickets."
+    system "You summarize articles for a UI card."
     rule "Return valid JSON only."
     user "{input}"
   end
 
   output_schema do
-    string :priority, enum: %w[low medium high urgent]
-    string :category
+    string :tldr
+    array  :takeaways, of: :string, min_items: 3, max_items: 5
+    string :tone, enum: %w[neutral positive negative analytical]
   end
 
-  validate("urgent needs justification") { |o, input| o[:priority] != "urgent" || input.length > 20 }
+  validate("TL;DR fits the card") { |o, _| o[:tldr].length <= 200 }
   retry_policy models: %w[gpt-4.1-mini gpt-4.1]
 end
 ```
@@ -43,22 +46,22 @@ end
 
 ```ruby
 # Before
-parsed = ClassifyService.new.call(ticket_text)
-Ticket.update!(priority: parsed["priority"])
+parsed = ArticleSummaryService.new.call(article_text)
+Article.update!(summary: parsed["tldr"])
 
 # After
-result = ClassifyTicket.run(ticket_text)
+result = SummarizeArticle.run(article_text)
 if result.ok?
-  Ticket.update!(priority: result.parsed_output[:priority])
+  Article.update!(summary: result.parsed_output[:tldr])
 else
-  Rails.logger.warn "Classification failed: #{result.status}"
+  Rails.logger.warn "Summary failed: #{result.status}"
 end
 ```
 
 ## Step 4: Add logging via around_call
 
 ```ruby
-class ClassifyTicket < RubyLLM::Contract::Step::Base
+class SummarizeArticle < RubyLLM::Contract::Step::Base
   # ... prompt, schema, validates ...
 
   around_call do |step, input, result|
@@ -79,22 +82,28 @@ end
 Use real inputs from production logs:
 
 ```ruby
-ClassifyTicket.define_eval("regression") do
-  add_case "billing", input: "I was charged twice", expected: { priority: "high" }
-  add_case "feature", input: "Add dark mode", expected: { priority: "low" }
-  add_case "outage", input: "Database is down", expected: { priority: "urgent" }
+SummarizeArticle.define_eval("regression") do
+  add_case "short news",
+           input: "Ruby 3.4 ships with frozen string literals by default...",
+           expected: { tone: "analytical" }
+
+  add_case "critical review",
+           input: "The new mesh networking hardware failed under load...",
+           expected: { tone: "negative" }
 end
 ```
 
 ## Step 6: Find the cheapest model
 
 ```ruby
-comparison = ClassifyTicket.compare_models("regression",
-  models: %w[gpt-4.1-nano gpt-4.1-mini])
+comparison = SummarizeArticle.compare_models("regression",
+  candidates: [{ model: "gpt-4.1-nano" }, { model: "gpt-4.1-mini" }])
 
 comparison.print_summary
 comparison.best_for(min_score: 0.95)  # => cheapest model at >= 95%
 ```
+
+Full optimization workflow — multi-eval, fallback list, production-mode cost — in [Optimizing retry_policy](optimizing_retry_policy.md).
 
 ## Step 7: Add CI gate
 
@@ -109,7 +118,7 @@ RubyLLM::Contract::RakeTask.new do |t|
 end
 ```
 
-**Rails apps:** If your adapter is configured in an initializer, use a Proc so context is resolved after Rails boots:
+**Rails apps:** if your adapter is configured in an initializer, use a Proc so context is resolved after Rails boots:
 
 ```ruby
 RubyLLM::Contract::RakeTask.new do |t|
@@ -121,7 +130,7 @@ end
 ## Common patterns
 
 | Old pattern | New pattern |
-|-------------|-------------|
+|---|---|
 | `LlmClient.new(model:).call(prompt)` | `MyStep.run(input)` |
 | `JSON.parse(response[:content])` | `result.parsed_output` |
 | `begin; rescue; retry; end` | `retry_policy models: [...]` |
@@ -132,34 +141,43 @@ end
 
 ## Anti-patterns
 
-**Don't migrate markdown/text output services.** The gem is for structured JSON. Prose output gets no benefit from schema validation.
-
-**Don't put parallelism in the gem.** Thread management is your app's concern. The gem provides the contract; you call it however you want.
-
-**Don't migrate all services at once.** Start with one. Validate the pattern. Then migrate the next.
+- **Don't migrate markdown/text output services.** The gem is for structured JSON. Prose output gets no benefit from schema validation.
+- **Don't put parallelism in the gem.** Thread management is your app's concern. The gem provides the contract; you call it however you want.
+- **Don't migrate all services at once.** Start with one. Validate the pattern. Then migrate the next.
 
 ## Parallel batch generation
 
 The gem handles single calls. You handle parallelism:
 
 ```ruby
-class GenerateBatch < RubyLLM::Contract::Step::Base
+class SummarizeBatch < RubyLLM::Contract::Step::Base
   output_schema do
-    array :items do; object do; string :name; end; end
+    array :summaries do
+      object do
+        string :article_id
+        string :tldr
+      end
+    end
   end
   retry_policy models: %w[gpt-4.1-mini gpt-4.1]
 end
 
 # Your orchestrator
 threads = 10.times.map do |i|
-  Thread.new { Rails.application.executor.wrap { GenerateBatch.run(input(i)) } }
+  Thread.new { Rails.application.executor.wrap { SummarizeBatch.run(input(i)) } }
 end
 results = threads.map(&:value)
 ```
 
-**Note:** In tests, `stub_step` overrides are thread-local. If your orchestrator spawns threads, propagate overrides manually:
+**Note:** in tests, `stub_step` overrides are thread-local. If your orchestrator spawns threads, propagate overrides manually:
 
 ```ruby
 overrides = RubyLLM::Contract.step_adapter_overrides.dup
-Thread.new { RubyLLM::Contract.step_adapter_overrides = overrides; GenerateBatch.run(input) }
+Thread.new { RubyLLM::Contract.step_adapter_overrides = overrides; SummarizeBatch.run(input) }
 ```
+
+## See also
+
+- [Getting Started](getting_started.md) — the full walkthrough of every feature `SummarizeArticle` uses.
+- [Testing](testing.md) — `stub_step` reference for migrating your test adapter mocks.
+- [Eval-First](eval_first.md) — how to build the "regression" eval from production logs.

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -1,5 +1,7 @@
 # Migration Guide
 
+> Read this when adopting the gem in an existing Rails app with a raw `LlmClient.call` service you want to replace. Skip if starting fresh — go to [Getting Started](getting_started.md) instead.
+
 How to adopt `ruby_llm-contract` in an existing Rails app. Examples use `SummarizeArticle` — the flagship step from the [README](../../README.md) — but the pattern applies to any single-input / structured-output service.
 
 ## Step 1: Start with the simplest service

--- a/docs/guide/optimizing_retry_policy.md
+++ b/docs/guide/optimizing_retry_policy.md
@@ -97,7 +97,7 @@ dense_article — model comparison
 - **effective cost** — total per successful output including retries.
 - **`—`** — candidate equals fallback, no chain to observe.
 
-Run this before finalizing: a candidate saving 3× on first-attempt but escalating 60% of the time may save only 1.2× in production.
+Run this before finalizing: a candidate saving 3× on first-attempt but falling back 60% of the time may save only 1.2× in production.
 
 **Scope.** Single-fallback (2-tier) chains only. Multi-tier inspect via `trace.attempts`. Step-level — calling on `Pipeline::Base` raises `ArgumentError`.
 

--- a/docs/guide/optimizing_retry_policy.md
+++ b/docs/guide/optimizing_retry_policy.md
@@ -41,7 +41,7 @@ LIVE=1 RUNS=3 rake ruby_llm_contract:optimize \
 Output (illustrative):
 
 ```
-SummarizeArticle — retry chain optimization
+SummarizeArticle — fallback list optimization
 
   eval             4.1-nano  4.1-mini@low  4.1-mini   4.1
   ---------------------------------------------------------
@@ -60,7 +60,7 @@ SummarizeArticle — retry chain optimization
 ```
 
 Reading the table:
-- **`←` marks scores below threshold in the hardest eval.** Not a selection hint — just "this candidate fails the constraining row".
+- **`←` marks scores below threshold in the hardest eval.** Not a selection hint — just "this candidate fails the row that matters most".
 - **Hardest eval** = the one that forces the strong fallback. Here, `critical_tone` demands `gpt-4.1-mini`.
 - **Suggested fallback list** = the shortest chain where each step covers more evals, built greedy-cheapest-first. Stops when all evals pass. Order matters: `gpt-4.1-nano` is tried first; on validation failure, the gem falls back to `gpt-4.1-mini`.
 

--- a/docs/guide/optimizing_retry_policy.md
+++ b/docs/guide/optimizing_retry_policy.md
@@ -1,389 +1,112 @@
-# Optimizing retry_policy
+# Find the cheapest viable fallback list
 
-How to find the cheapest retry chain that passes all your evals.
+You defined `SummarizeArticle` in the [README](../../README.md) with `retry_policy models: %w[gpt-4.1-nano gpt-4.1-mini gpt-4.1]`. That list was a guess. `optimize_retry_policy` tells you which models your evals actually need, so you stop paying for the strong model when `nano` was enough — or stop shipping `nano` when the hardest eval proves it isn't.
 
-## Prerequisites
+## Requirements
 
-This guide assumes your app already has:
+- **`SummarizeArticle` already has `retry_policy`.** If your step has none, add one first ([getting started](getting_started.md)).
+- **2–3 evals per step.** One eval optimizes for one scenario; with only `smoke`, you get a recommendation that passes smoke but may miss production edge cases. See [eval-first](eval_first.md).
+- **Rake tasks.** The standard `RubyLLM::Contract::RakeTask` includes `ruby_llm_contract:optimize`. Non-Rails projects: set `EVAL_DIRS=...`.
 
-**1. A Step with `retry_policy`.** This is the escalation chain that runs progressively stronger models when validation fails:
-
-```ruby
-class ClassifyThread < RubyLLM::Contract::Step::Base
-  output_schema do
-    string :classification, enum: %w[PROMO FILLER SKIP]
-  end
-
-  validate("PROMO has matched page") { |o| o[:classification] != "PROMO" || o[:matched_page].present? }
-
-  retry_policy models: %w[gpt-5-mini gpt-5-mini gpt-4.1]
-end
-```
-
-If your step has no `retry_policy`, add one first. See [Getting Started](getting_started.md).
-
-**2. At least 2–3 evals per step.** Each eval is a scenario with input, sample response, and verify checks that assert correctness:
+For this guide, assume `SummarizeArticle` has three evals:
 
 ```ruby
-ClassifyThread.define_eval("smoke") do
-  default_input({ threads: [...], url: "https://example.com" })
-  sample_response({ threads: [{ id: "t1", classification: "PROMO" }, ...] })
-
-  verify "relevant thread is PROMO", ->(o) { o[:threads].find { |t| t[:id] == "t1" }[:classification] == "PROMO" }
-  verify "spam thread is SKIP",      ->(o) { o[:threads].find { |t| t[:id] == "t2" }[:classification] == "SKIP" }
-end
+SummarizeArticle.define_eval("smoke")          { ... }  # short news article
+SummarizeArticle.define_eval("dense_article")  { ... }  # long form, 5 takeaways required
+SummarizeArticle.define_eval("critical_tone")  { ... }  # negative review, tone must match
 ```
 
-**Why 2–3 evals minimum?** One eval tests one scenario. `recommend` optimizes for the eval you give it — if you only have `smoke`, you'll get a recommendation that passes smoke but may fail edge cases in production. The more evals, the safer the recommendation.
+## Offline check first
 
-See [Eval-First Development](eval_first.md) for how to write evals.
-
-**3. Rake tasks for `recommend` and `compare_models`.** If you use the standard `RakeTask`, these are included. If not, you need a way to run `Step.recommend(eval_name, candidates: [...])` — see the [testing guide](testing.md) for programmatic usage.
-
-## The problem
-
-`recommend` runs on **one eval at a time**. If you optimize for `smoke` alone, you may pick a cheap model that fails harder evals like `topic_mismatch`. The cheapest model per eval varies — the retry chain must satisfy the **constraining eval** (the hardest one).
-
-## One command: `optimize`
+Run once offline to verify the wiring:
 
 ```bash
-rake ruby_llm_contract:optimize STEP=MyStep CANDIDATES=cheap-model,mid-model@low,mid-model,expensive-model
+rake ruby_llm_contract:optimize \
+  STEP=SummarizeArticle \
+  CANDIDATES=gpt-4.1-nano,gpt-4.1-mini@low,gpt-4.1-mini,gpt-4.1
 ```
 
-By default this runs **offline** using each eval's `sample_response` (zero API calls). To run against real models:
+Offline uses each eval's `sample_response` — zero API calls. **Every candidate gets the same score** because they all receive the canned response. That's fine for a smoke test (verifying evals load, candidates parse, output renders) but it doesn't compare model quality. For real optimization, go live.
+
+## Optimize against real models
 
 ```bash
-# Live mode — makes real API calls:
-LIVE=1 rake ruby_llm_contract:optimize STEP=MyStep CANDIDATES=...
-
-# Non-Rails projects — specify where eval files live:
-EVAL_DIRS=lib/steps/eval rake ruby_llm_contract:optimize STEP=MyStep CANDIDATES=...
+LIVE=1 RUNS=3 rake ruby_llm_contract:optimize \
+  STEP=SummarizeArticle \
+  CANDIDATES=gpt-4.1-nano,gpt-4.1-mini@low,gpt-4.1-mini,gpt-4.1
 ```
 
-This runs `compare_models` on **every eval** for the step, builds the score table, finds the constraining eval, and prints a suggested retry chain with copy-paste DSL:
+`LIVE=1` makes real API calls. `RUNS=3` averages each `(candidate, eval)` pair over three runs — necessary because OpenAI forces `temperature=1.0` on gpt-5 / o-series and the same pair can score `0.00` on one run and `1.00` on the next.
+
+Output (illustrative):
 
 ```
-MyStep — retry chain optimization
+SummarizeArticle — retry chain optimization
 
-  eval                 cheap   mid@low   mid    expensive
-  -------------------------------------------------------
-  smoke                 1.00      1.00   1.00       1.00
-  edge_cases            0.67 ←    0.67   1.00       1.00
-  locale                1.00      1.00   1.00       1.00
+  eval             4.1-nano  4.1-mini@low  4.1-mini   4.1
+  ---------------------------------------------------------
+  smoke                1.00          1.00      1.00  1.00
+  dense_article        0.67 ←        1.00      1.00  1.00
+  critical_tone        0.50 ←        0.67 ←    1.00  1.00
 
-  Constraining eval: edge_cases
+  Hardest eval: critical_tone
 
-  Suggested chain:
-    cheap    — passes 2/3 evals
-    mid      — passes 3/3 evals
+  Suggested fallback list:
+    gpt-4.1-nano         — covers 1 eval(s)
+    gpt-4.1-mini         — passes all 3 evals
 
   DSL:
-    retry_policy models: %w[cheap mid]
+    retry_policy models: %w[gpt-4.1-nano gpt-4.1-mini]
 ```
 
-Copy the DSL, paste into your step, run `rake ruby_llm_contract:eval` to verify.
+Reading the table:
+- **`←` marks scores below threshold in the hardest eval.** Not a selection hint — just "this candidate fails the constraining row".
+- **Hardest eval** = the one that forces the strong fallback. Here, `critical_tone` demands `gpt-4.1-mini`.
+- **Suggested fallback list** = the shortest chain where each step covers more evals, built greedy-cheapest-first. Stops when all evals pass. Order matters: `gpt-4.1-nano` is tried first; on validation failure, the gem falls back to `gpt-4.1-mini`.
 
-## Reducing variance with `runs:`
+Copy the DSL, paste into your step, verify with `rake ruby_llm_contract:eval`. You just dropped `gpt-4.1` from the chain — most requests finish on nano, mini handles what nano misses, and the strong model was never needed.
 
-In **live mode** the LLM is non-deterministic. The same `(candidate, eval)` pair can score `0.00`, `0.50`, or `1.00` across runs even with identical prompts. `optimize` runs each candidate exactly once by default, so one unlucky sample can flip a viable candidate to "failing" and trigger a misleading **"no viable chain"** result.
+## Measure effective cost before shipping
 
-### Why you can't just lower temperature
+`optimize` shows **first-attempt** cost. In production, a candidate whose validator rejects 20% of outputs actually costs `first_try_cost + fallback_cost × 0.20` per successful output. The first-attempt number hides this.
 
-OpenAI enforces `temperature=1.0` for the gpt-5 / o-series models server-side (ruby_llm normalizes any other value to 1.0 per provider requirement). You cannot request `temperature: 0.3` to reduce variance. **Averaging over N runs is the only reliable way to get stable eval scores.**
-
-### When to use it
-
-Use `runs: > 1` when:
-
-- You're running **live** (`LIVE=1` / real API calls), AND
-- The candidate pool includes a gpt-5 / o-series model, OR
-- You've seen inconsistent `optimize` results across re-runs ("it said no viable chain, but a manual re-run passed").
-
-Skip it when:
-
-- Running **offline** with `sample_response` — outputs are deterministic, `runs > 1` wastes cycles with no benefit.
-- You only care about a ballpark signal and budget matters more than precision.
-
-### How to use it
-
-```bash
-# CLI — optimize with 3 runs per candidate per eval:
-LIVE=1 RUNS=3 rake ruby_llm_contract:optimize STEP=MyStep CANDIDATES=gpt-5-nano,gpt-5-mini@low,gpt-5-mini
-```
+`production_mode: { fallback: "..." }` runs each candidate with a runtime `[candidate, fallback]` chain and reports effective cost:
 
 ```ruby
-# Programmatic:
-MyStep.optimize_retry_policy(
-  candidates: [{ model: "gpt-5-nano" }, { model: "gpt-5-mini", reasoning_effort: "low" }],
-  runs: 3
-)
-
-# Or directly on compare_models:
-MyStep.compare_models("edge_cases", candidates: [...], runs: 3)
-```
-
-### What you pay
-
-Cost scales linearly: `runs: 3` makes 3× the API calls. Start with `runs: 3` — enough signal to separate stable candidates from variance, without breaking the budget on large candidate pools.
-
-### What the report contains
-
-Each candidate's aggregated report exposes:
-
-- `score` — **mean** across runs (used in the table and chain-building)
-- `score_min`, `score_max` — spread across runs (inspect for high-variance candidates)
-- `total_cost` — **mean total eval cost per run** (sum of all case costs, averaged across runs; divide by case count for an approximate per-call cost)
-- `pass_rate` — `"x/N"` where `x` is the count of runs that passed cleanly (every case passing)
-- `pass_rate_ratio` — `clean_passes / N` as a float (run-level reliability, consistent with `pass_rate`)
-- `clean_passes` — the same `x` as an integer
-
-With `runs: 1` (default), `compare_models` returns a plain `Report` — no wrapping, no behavior change.
-
-## Manual procedure (if you need more control)
-
-### 1. List evals for the step
-
-```ruby
-MyStep.eval_names  # => ["smoke", "edge_cases", "locale"]
-```
-
-### 2. Run recommend on every eval
-
-```bash
-rake ruby_llm_contract:recommend STEP=MyStep EVAL=smoke         CANDIDATES=cheap-model,mid-model@low,mid-model,expensive-model
-rake ruby_llm_contract:recommend STEP=MyStep EVAL=edge_cases    CANDIDATES=cheap-model,mid-model@low,mid-model,expensive-model
-rake ruby_llm_contract:recommend STEP=MyStep EVAL=locale        CANDIDATES=cheap-model,mid-model@low,mid-model,expensive-model
-```
-
-Running on only one eval gives a misleadingly cheap recommendation.
-
-### 3. Build the score table
-
-Collect results into a table. The **constraining eval** is the row that needs the strongest model.
-
-### 4. Build the escalation chain
-
-Read column by column, cheapest first. Each step covers more evals. Stop when all evals pass.
-
-### 5. Verify
-
-```bash
-rake ruby_llm_contract:eval
-```
-
-## Interpreting results: 5 real cases
-
-These are patterns from a real project optimization. Each case is a scenario where raw `optimize` output misled the first read — and how to diagnose and act.
-
-### Case 1: "No viable chain" is often a single-run fluke
-
-**Symptom:** `optimize` reports `minimum_substance: 0.00` on every candidate, prints "No viable chain". But manually re-running the step on the same input produces clean output.
-
-**Diagnosis:** Single-run variance. With gpt-5 models (OpenAI forces `temperature=1.0`), one sample can land below threshold while the next three pass.
-
-**Action:** Re-run with `RUNS=3`. If scores jump to 1.00, the original verdict was noise.
-
-```bash
-LIVE=1 RUNS=3 rake ruby_llm_contract:optimize STEP=MyStep CANDIDATES=...
-```
-
-**Rule of thumb:** never trust "No viable chain" from a single run. Re-run with `RUNS=3` before blaming models.
-
-### Case 2: Higher reasoning effort can make a candidate WORSE
-
-**Symptom:** You assume upgrading `mini@low → mini@medium` for a problematic eval will help. The opposite happens — score drops from 0.33 to 0.00.
-
-**Diagnosis:** For evals that assert conciseness ("short playful reply", "no prescriptive tail"), more reasoning produces **more** structured output ("Step 1:", "Key point:", numbered steps). The model "thinks harder" and writes a more elaborate answer — the opposite of what a playful thread needs.
-
-**Action:** Test before assuming. On conciseness evals, consider **lower** effort or even a smaller model.
-
-```ruby
-# Targeted hypothesis check — call compare_models directly:
-adapter = RubyLLM::Contract::Adapters::RubyLLM.new
-MyStep.compare_models(
-  "playful_reply",
-  candidates: [
-    { model: "gpt-5-mini", reasoning_effort: "low" },
-    { model: "gpt-5-mini", reasoning_effort: "medium" },
-    { model: "gpt-5-mini", reasoning_effort: "high" }
-  ],
-  context: { adapter: adapter },
-  runs: 3
+SummarizeArticle.compare_models(
+  "dense_article",
+  candidates: [{ model: "gpt-4.1-nano" }, { model: "gpt-4.1-mini", reasoning_effort: "low" }],
+  production_mode: { fallback: "gpt-4.1-mini" }
 ).print_summary
 ```
 
-**Rule of thumb:** don't assume bigger model / higher effort = better. For "keep it short and natural" evals, it often goes the other way.
-
-### Case 3: Nano variants can beat mini on specific evals
-
-**Symptom:** You check `mini@low` and `mini@medium`, both fail. You conclude "need a bigger fallback".
-
-**Actual finding:** `nano@medium` scores 1.00 where both mini variants fail.
-
-**Diagnosis:** Nano at higher reasoning effort can be more disciplined than mini. On tasks demanding conciseness, small-model + medium-effort outperforms large-model + low-effort.
-
-| model variant | conciseness eval | generic reasoning eval |
-|---|---|---|
-| nano@low | 0.83 | 0.78 |
-| nano@medium | **1.00** | 0.89 |
-| mini@low | 0.33 | 1.00 |
-| mini@medium | 0.00 | (not tested) |
-
-**Action:** Include both axes in the candidate pool — model size AND reasoning_effort. Don't fix one and vary only the other.
-
-```bash
-# 2D search, not 1D:
-CANDIDATES=nano@low,nano@medium,mini@low,mini@medium
-```
-
-### Case 4: "No viable chain" from multiple candidates usually means the eval is too strict
-
-**Symptom:** Every candidate — including the most expensive — scores 0.50 on the same eval.
-
-**Diagnosis:** If the strongest model fails, the eval is rejecting a correct answer. Common cause: a `verify` block asserts one specific label when multiple labels are semantically valid.
-
-**Real example:** An eval expected `classification == "SKIP"` for an off-topic thread, but the model correctly returned `FILLER` (off-topic but still reply-able). Every model scored 0.50 because the eval's verdict was too narrow.
-
-**Action:**
-
-1. Run the step directly on the eval input, inspect the output. If the step has a `retry_policy`, override it so `context[:model]` actually takes effect:
-   ```ruby
-   MyStep.run(
-     eval_input,
-     context: { model: "gpt-5-mini", adapter: adapter, retry_policy_override: nil }
-   )
-   # Without retry_policy_override, the configured retry chain wins and context[:model] is ignored.
-   ```
-2. Compare with what the verify block expects.
-3. If the output is **correct but rejected**, loosen the verify block to accept valid variants:
-   ```ruby
-   verify "cat thread is not PROMO",
-     expect: ->(o) { %w[FILLER SKIP].include?(o[:classification]) }
-   ```
-4. Re-run optimize. The "viable chain" appears.
-
-**Rule of thumb:** when every candidate fails the same eval, the eval is probably wrong. Fix the eval before blaming models.
-
-### Case 5: Use targeted `compare_models` for hypothesis testing
-
-**Symptom:** You suspect upgrading `mini@low → mini@medium` on one specific eval. You run `optimize` which re-checks all evals for every candidate — with 4 evals × 2 candidates × RUNS=3 that's **24 live API calls**, most of them repeating known-good results.
-
-**Action:** For hypothesis testing, call `Step.compare_models` directly on the single constraining eval. Cheap, focused, answers the question:
-
-```ruby
-# Full optimize: 4 evals × 2 candidates × RUNS=3 = 24 calls
-MyStep.optimize_retry_policy(
-  candidates: [
-    { model: "gpt-5-mini", reasoning_effort: "low" },
-    { model: "gpt-5-mini", reasoning_effort: "medium" }
-  ],
-  context: { adapter: adapter },
-  runs: 3
-)
-
-# Targeted test: 1 eval × 1 candidate × RUNS=3 = 3 calls
-MyStep.compare_models(
-  "constraining_eval",
-  candidates: [{ model: "gpt-5-mini", reasoning_effort: "medium" }],
-  context: { adapter: adapter },
-  runs: 3
-).print_summary
-```
-
-**Rule of thumb:** `optimize_retry_policy` to find the constraining eval. `compare_models` on that eval to test a specific hypothesis.
-
-### Meta: when to act on a finding
-
-| finding | reliable signal? | action |
-|---|---|---|
-| Score in a single run (RUNS=1) | **NO** | re-run with RUNS=3 before deciding |
-| Score stable across RUNS=3 | yes | trust the ranking |
-| Every candidate fails one eval | NO — eval likely wrong | inspect step output vs verify |
-| Higher effort helps | model-specific | test, don't assume |
-| Disjoint coverage (A passes e1, B passes e2) | — | retry won't bridge it (see [semantic gap note](../../lib/ruby_llm/contract/eval/retry_optimizer.rb)) |
-
-## Troubleshooting: "no recommendation"
-
-When `recommend` returns "no recommendation" for all candidates on an eval, the issue is usually the eval, not the models.
-
-**Check the eval's verify blocks.** If every model — including the strongest — scores below threshold, a verify check likely expects an overly strict answer. Common case: an eval expects `SKIP` when `FILLER` is also a correct classification.
-
-**Diagnose:** run the step directly on the eval input, inspect the output, and compare with what verify expects.
-
-**Fix the eval to accept all valid outputs**, then re-run recommend. Do not loosen evals to make cheap models pass — fix evals that reject correct answers.
-
-## Example: real optimization
-
-Before:
-
-```ruby
-# Every attempt uses the same mid-tier model
-retry_policy models: %w[gpt-5-mini gpt-5-mini gpt-4.1]
-```
-
-After running recommend on 6 evals:
+Output (live mode, illustrative):
 
 ```
-                        nano   mini@low   mini   4.1
-smoke                   0.67   1.00       1.00   1.00
-same_locale_page_fit    1.00   1.00       1.00   1.00
-hostile_recommendation  1.00   1.00       1.00   1.00
-non_promo_same_domain   1.00   1.00       1.00   1.00
-locale_mismatch         1.00   1.00       1.00   1.00
-topic_mismatch          0.67   0.67       1.00   1.00  ← constraining
+dense_article — model comparison
+
+  Chain                                      first-attempt  fallback %  effective cost  latency   score
+  -----------------------------------------------------------------------------------------------------
+  gpt-4.1-nano → gpt-4.1-mini                $0.0010        33%         $0.0018         164ms     1.00
+  gpt-4.1-mini (effort: low) → gpt-4.1-mini  $0.0015         5%         $0.0016         210ms     1.00
+  gpt-4.1-mini                               $0.0030         —          $0.0030         220ms     1.00
 ```
 
-Result:
+- **first-attempt** — cost of the first run alone.
+- **fallback %** — fraction of cases where the validator rejected and the fallback ran.
+- **effective cost** — total per successful output including retries.
+- **`—`** — candidate equals fallback, no chain to observe.
 
-```ruby
-retry_policy do
-  escalate(
-    { model: "gpt-5-nano" },                           # $0.001, passes 4/6
-    { model: "gpt-5-mini", reasoning_effort: "low" },  # $0.002, passes 5/6
-    { model: "gpt-5-mini" }                            # $0.003, passes 6/6
-  )
-end
-```
+Run this before finalizing: a candidate saving 3× on first-attempt but escalating 60% of the time may save only 1.2× in production.
 
-First attempt 4× cheaper. Worst case 2.7× cheaper. Same eval coverage.
+**Scope.** Single-fallback (2-tier) chains only. Multi-tier inspect via `trace.attempts`. Step-level — calling on `Pipeline::Base` raises `ArgumentError`.
 
-## Production-mode cost measurement
+## When results look wrong
 
-The default `compare_models` / `optimize_retry_policy` output shows **single-shot** cost — what each candidate costs when it runs alone on the first attempt. In production, a cheaper candidate whose validator rejects 20% of outputs actually costs `first_try_cost + fallback_cost × 0.20` per successful output. The single-shot number understates this.
+- **"No viable chain" from a single live run.** Re-run with `RUNS=3`. If scores jump, the first run was noise. Never trust single-run results with gpt-5 / o-series in the pool — `temperature=1.0` is server-enforced.
+- **Every candidate fails the same eval**, including the strongest. The eval is rejecting correct answers. Run the step directly (`context: { retry_policy_override: nil, model: "gpt-4.1" }`), inspect the output, compare with the `verify` block. Loosen the eval if the output is correct but not one of the accepted values.
+- **Testing one specific hypothesis.** (e.g. "does `mini@medium` help on `critical_tone`?") Use `SummarizeArticle.compare_models("critical_tone", candidates: [{ model: "gpt-4.1-mini", reasoning_effort: "medium" }], runs: 3)` directly — three calls instead of rerunning the whole optimize pass.
 
-Pass `production_mode: { fallback: "..." }` to measure the true effective cost:
+## Programmatic API names
 
-```ruby
-ClassifyTicket.compare_models(
-  "edge_cases",
-  candidates: [{ model: "gpt-5-nano" }, { model: "gpt-5-mini", reasoning_effort: "low" }],
-  production_mode: { fallback: "gpt-5-mini" }
-).print_summary
-```
-
-Output:
-
-```
-  Chain                        single-shot  escalation  effective cost  latency    score
-  -----------------------------------------------------------------------------------------
-  gpt-5-nano → gpt-5-mini      $0.0010      20%         $0.0016         164ms       1.00
-  gpt-5-mini (effort: low) → …  $0.0015      5%          $0.0016          210ms       1.00
-  gpt-5-mini                    $0.0030      —           $0.0030          220ms       1.00
-```
-
-**Reading the table:**
-
-- **`single-shot`** — cost of the 1st attempt alone (matches the classic table).
-- **`escalation`** — fraction of cases where the candidate's validator rejected the first output and the fallback ran as a retry.
-- **`effective cost`** — sum of all attempted costs per case, averaged. This is what you actually pay per successful output in production.
-- **`—` in escalation** (em-dash, not 0%) — appears when the candidate equals the fallback. The row is a pure single-shot eval; there's no escalation chain to observe. `effective == single-shot` by construction.
-
-**Interaction with `runs:`.** `production_mode: { fallback: } + runs: 3` averages every metric — including `escalation_rate` — across runs. A single-run escalation rate inherits the same variance as a single-run score (cf. [Reducing variance with `runs:`](#reducing-variance-with-runs)).
-
-**Scope.** `production_mode:` supports **single-fallback (2-tier)** chains only. Multi-tier chains can still be inspected post-hoc via `trace.attempts`, but the table summarizes 2-tier. Empirically, 2-tier covers the common case where one cheap model handles easy inputs and one safe model catches the rest.
-
-**Step-only.** `production_mode:` is a Step-level feature — retry injection happens in `Step#run` via `context[:retry_policy_override]`. Calling `compare_models` with `production_mode:` on a `Pipeline::Base` subclass raises `ArgumentError`. Benchmark individual steps instead.
-
-**When to use it.** Run it before finalizing a retry chain: a candidate that saves 3× on single-shot but escalates 60% of the time may save only 1.2× in production. The classic table hides this; production-mode surfaces it.
-
-**Programmatic access.** All metrics are exposed on `Report` / `AggregatedReport`: `escalation_rate`, `single_shot_cost`, `effective_cost`, `single_shot_latency_ms`, `effective_latency_ms`, `latency_percentiles` (`{p50:, p95:, max:}`).
+Metrics exposed on `Report` / `AggregatedReport` keep their original names: `single_shot_cost`, `single_shot_latency_ms`, `escalation_rate`. The optimize Result struct also exposes `hardest_eval` as an alias for `constraining_eval`.

--- a/docs/guide/optimizing_retry_policy.md
+++ b/docs/guide/optimizing_retry_policy.md
@@ -1,5 +1,7 @@
 # Find the cheapest viable fallback list
 
+> Read this when you have 2+ evals and want to know empirically — not by guessing — which models belong in `retry_policy` and in what order.
+
 You defined `SummarizeArticle` in the [README](../../README.md) with `retry_policy models: %w[gpt-4.1-nano gpt-4.1-mini gpt-4.1]`. That list was a guess. `optimize_retry_policy` tells you which models your evals actually need, so you stop paying for the strong model when `nano` was enough — or stop shipping `nano` when the hardest eval proves it isn't.
 
 ## Requirements

--- a/docs/guide/output_schema.md
+++ b/docs/guide/output_schema.md
@@ -78,6 +78,8 @@ end
 |-----------|-------|---------|
 | `enum` | string, integer | `string :status, enum: %w[active inactive]` |
 | `minimum` / `maximum` | number, integer | `number :score, minimum: 0, maximum: 100` |
-| `minLength` / `maxLength` | string | `string :name, minLength: 1, maxLength: 100` |
-| `minItems` / `maxItems` | array | `array :tags, minItems: 1, maxItems: 10` |
-| `additionalProperties` | object | Set to `false` in schema to reject extra keys |
+| `min_length` / `max_length` | string | `string :name, min_length: 1, max_length: 100` |
+| `min_items` / `max_items` | array | `array :tags, min_items: 1, max_items: 10` |
+| `additional_properties` | object | Set to `false` in schema to reject extra keys |
+
+Keyword args use Ruby snake_case (`min_length`, `min_items`). The DSL converts them internally to JSON Schema's camelCase (`minLength`, `minItems`) before sending the schema to the provider — you do not need to write camelCase in Ruby.

--- a/docs/guide/output_schema.md
+++ b/docs/guide/output_schema.md
@@ -5,52 +5,51 @@ Declare the expected output structure using [ruby_llm-schema](https://github.com
 1. **Output validation** — replaces structural validates (enums, ranges, required fields). One declaration instead of many.
 2. **Provider-side enforcement** — with the RubyLLM adapter, the schema is sent to the LLM provider via `chat.with_schema(...)`, so the model is **forced** to return JSON matching the schema.
 
+All examples below extend the `SummarizeArticle` step from the [README](../../README.md).
+
 ## Schema replaces structural validates
 
 ```ruby
 # WITHOUT schema — many validates:
-validate("must include intent") { |o| o[:intent].to_s != "" }
-validate("intent must be allowed") { |o| %w[sales support billing].include?(o[:intent]) }
-validate("confidence must be a number") { |o| o[:confidence].is_a?(Numeric) }
-validate("confidence in range") { |o| o[:confidence]&.between?(0.0, 1.0) }
+validate("tldr must be a string")          { |o| o[:tldr].is_a?(String) }
+validate("takeaways must be an array")     { |o| o[:takeaways].is_a?(Array) }
+validate("takeaways 3 to 5")               { |o| (3..5).cover?(o[:takeaways].size) }
+validate("tone must be an allowed label")  { |o| %w[neutral positive negative analytical].include?(o[:tone]) }
 
 # WITH schema — one declaration:
 output_schema do
-  string :intent, enum: %w[sales support billing]
-  number :confidence, minimum: 0.0, maximum: 1.0
+  string :tldr
+  array  :takeaways, of: :string, min_items: 3, max_items: 5
+  string :tone, enum: %w[neutral positive negative analytical]
 end
 ```
 
 ## Nested objects in arrays
 
-Use `object do...end` inside `array`:
+Use `object do...end` inside `array` when you need more than a primitive per element. If `SummarizeArticle` grows to attach confidence per takeaway:
 
 ```ruby
 output_schema do
-  string :locale
-  array :groups, min_items: 1, max_items: 3 do
+  string :tldr
+  array :takeaways, min_items: 3, max_items: 5 do
     object do
-      string :who
-      array :use_cases do
-        string
-      end
-      array :tags do
-        string
-      end
+      string :text
+      number :confidence, minimum: 0.0, maximum: 1.0
     end
   end
+  string :tone, enum: %w[neutral positive negative analytical]
 end
 ```
 
 ## Schema pattern reference
 
 | Your output looks like | Schema pattern | Example |
-|------------------------|---------------|---------|
-| `{"intent": "billing", "score": 0.9}` | Flat fields | `string :intent; number :score` |
-| `{"tags": ["ruby", "llm"]}` | Array of primitives | `array :tags do; string; end` |
-| `{"groups": [{"who": "...", "tags": [...]}]}` | Array of objects | `array :groups do; object do; string :who; end; end` |
+|---|---|---|
+| `{"tldr": "...", "tone": "positive"}` | Flat fields | `string :tldr; string :tone, enum: [...]` |
+| `{"takeaways": ["...", "..."]}` | Array of primitives | `array :takeaways, of: :string, min_items: 3, max_items: 5` |
+| `{"takeaways": [{"text": "...", "confidence": 0.9}]}` | Array of objects | `array :takeaways do; object do; string :text; number :confidence; end; end` |
 
-The schema tells the LLM provider **exactly** what JSON structure to return. Without `object do...end`, `array :groups do; string :who; end` tells the provider "groups is an array of strings" — and that's what you get back.
+Without `object do...end`, `array :takeaways do; string :text; end` tells the provider "takeaways is an array of strings" — not objects. That's what you get back.
 
 ## Why schema alone is not enough
 
@@ -58,28 +57,32 @@ Schema validates **shape** — correct types, allowed values, field presence. Bu
 
 ```ruby
 output_schema do
-  string :intent, enum: %w[sales support billing]
-  number :confidence, minimum: 0.0, maximum: 1.0
+  string :tldr
+  array  :takeaways, of: :string, min_items: 3, max_items: 5
+  string :tone, enum: %w[neutral positive negative analytical]
 end
 
-# Schema says lang must be a string — but doesn't know what language you ASKED for.
-validate("language must match requested") { |output, input| output[:lang] == input[:lang] }
+# Schema allows any string for :tldr — but a 500-char "summary" breaks the UI card.
+validate("TL;DR fits the card") { |o, _| o[:tldr].length <= 200 }
 
-# Schema says confidence is 0.0-1.0 — but can't express conditional logic.
-validate("high confidence for extreme sentiments") do |o|
-  next true if o[:intent] == "other"
-  o[:confidence] >= 0.7
+# Schema enforces 3–5 takeaways — but says nothing about them being distinct.
+validate("takeaways are unique") { |o, _| o[:takeaways].uniq.size == o[:takeaways].size }
+
+# Schema can't express cross-field rules.
+validate("critical tone requires at least one concrete risk") do |o, _|
+  next true unless o[:tone] == "negative"
+  o[:takeaways].any? { |t| t.match?(/fail|break|crash|outage|vulnerab/i) }
 end
 ```
 
 ## Supported constraints
 
 | Constraint | Types | Example |
-|-----------|-------|---------|
-| `enum` | string, integer | `string :status, enum: %w[active inactive]` |
-| `minimum` / `maximum` | number, integer | `number :score, minimum: 0, maximum: 100` |
-| `min_length` / `max_length` | string | `string :name, min_length: 1, max_length: 100` |
-| `min_items` / `max_items` | array | `array :tags, min_items: 1, max_items: 10` |
-| `additional_properties` | object | Set to `false` in schema to reject extra keys |
+|---|---|---|
+| `enum` | string, integer | `string :tone, enum: %w[neutral positive negative analytical]` |
+| `minimum` / `maximum` | number, integer | `number :confidence, minimum: 0.0, maximum: 1.0` |
+| `min_length` / `max_length` | string | `string :tldr, min_length: 1, max_length: 200` |
+| `min_items` / `max_items` | array | `array :takeaways, of: :string, min_items: 3, max_items: 5` |
+| `additional_properties` | object | Set to `false` in the schema to reject extra keys |
 
-Keyword args use Ruby snake_case (`min_length`, `min_items`). The DSL converts them internally to JSON Schema's camelCase (`minLength`, `minItems`) before sending the schema to the provider — you do not need to write camelCase in Ruby.
+Keyword args use Ruby snake_case (`min_length`, `min_items`). The DSL converts them internally to JSON Schema's camelCase (`minLength`, `minItems`) before sending the schema to the provider — you don't need to write camelCase in Ruby.

--- a/docs/guide/output_schema.md
+++ b/docs/guide/output_schema.md
@@ -1,5 +1,7 @@
 # Output Schema
 
+> Read this as a reference for the schema DSL — every constraint, nested objects, arrays of objects, the full pattern table.
+
 Declare the expected output structure using [ruby_llm-schema](https://github.com/danielfriis/ruby_llm-schema) DSL. The schema serves **two purposes**:
 
 1. **Output validation** — replaces type and shape checks (enums, ranges, required fields). One declaration instead of many.

--- a/docs/guide/output_schema.md
+++ b/docs/guide/output_schema.md
@@ -3,7 +3,7 @@
 Declare the expected output structure using [ruby_llm-schema](https://github.com/danielfriis/ruby_llm-schema) DSL. The schema serves **two purposes**:
 
 1. **Output validation** — replaces type and shape checks (enums, ranges, required fields). One declaration instead of many.
-2. **Provider-side enforcement** — with the RubyLLM adapter, the schema is sent to the LLM provider via `chat.with_schema(...)`, so the model is **forced** to return JSON matching the schema.
+2. **Provider-side request** — with the RubyLLM adapter, the schema is sent to the LLM provider via `chat.with_schema(...)`, asking the model to return JSON matching the shape. Cheaper models sometimes ignore the request, which is why client-side validation (point 1) still matters.
 
 All examples below extend the `SummarizeArticle` step from the [README](../../README.md).
 

--- a/docs/guide/output_schema.md
+++ b/docs/guide/output_schema.md
@@ -26,7 +26,7 @@ end
 
 ## Nested objects in arrays
 
-Use `object do...end` inside `array` when you need more than a primitive per element. If `SummarizeArticle` grows to attach confidence per takeaway:
+Use `object do...end` inside `array` when you need more than a primitive per element. Concrete scenario: the UI card grows a "confidence bar" next to each takeaway so editors can see which points the model was sure about vs guessing. That requires `confidence` paired with `text`, not two parallel arrays that could desync. Nested objects make the pairing a schema invariant:
 
 ```ruby
 output_schema do

--- a/docs/guide/output_schema.md
+++ b/docs/guide/output_schema.md
@@ -2,12 +2,12 @@
 
 Declare the expected output structure using [ruby_llm-schema](https://github.com/danielfriis/ruby_llm-schema) DSL. The schema serves **two purposes**:
 
-1. **Output validation** — replaces structural validates (enums, ranges, required fields). One declaration instead of many.
+1. **Output validation** — replaces type and shape checks (enums, ranges, required fields). One declaration instead of many.
 2. **Provider-side enforcement** — with the RubyLLM adapter, the schema is sent to the LLM provider via `chat.with_schema(...)`, so the model is **forced** to return JSON matching the schema.
 
 All examples below extend the `SummarizeArticle` step from the [README](../../README.md).
 
-## Schema replaces structural validates
+## Schema replaces type and shape checks
 
 ```ruby
 # WITHOUT schema — many validates:

--- a/docs/guide/pipeline.md
+++ b/docs/guide/pipeline.md
@@ -2,102 +2,85 @@
 
 Chain multiple steps with automatic data threading, fail-fast, per-step models, trace, and timeout.
 
-## Full example: Meeting transcript to follow-up email
+A pipeline needs more than one step to be interesting. This guide grows the `SummarizeArticle` step from the [README](../../README.md) into a three-step content pipeline that tags and routes the summary to a UI card.
 
-Three steps, three different LLM skills, three contracts:
+## Full example: article → summary → hashtags → card
 
 ```ruby
-# Step 1: Extract — the LLM is a "listener" parsing a messy transcript
-class ExtractDecisions < RubyLLM::Contract::Step::Base
-  output_schema do
-    array :decisions do
-      string :id
-      string :description
-      string :made_by
-    end
-    array :action_items do
-      string :id
-      string :task
-      string :owner
-      string :deadline
-    end
-  end
-
+# Step 1 — the flagship step from README, unchanged.
+class SummarizeArticle < RubyLLM::Contract::Step::Base
   prompt <<~PROMPT
-    Extract decisions and action items from a meeting transcript.
-    Only include decisions explicitly stated, never infer.
-    Assign sequential IDs: D1, D2, ... for decisions, A1, A2, ... for action items.
+    Summarize this article for a UI card. Return a short TL;DR,
+    3 to 5 key takeaways, and a tone label.
 
     {input}
   PROMPT
+
+  output_schema do
+    string :tldr
+    array  :takeaways, of: :string, min_items: 3, max_items: 5
+    string :tone, enum: %w[neutral positive negative analytical]
+  end
+
+  validate("TL;DR fits the card") { |o, _| o[:tldr].length <= 200 }
 end
 
-# Step 2: Analyze — the LLM is a "critic" finding vague assignments
-class ResolveAmbiguities < RubyLLM::Contract::Step::Base
+# Step 2 — reads SummarizeArticle's output, produces hashtags suitable for social posts.
+class GenerateHashtags < RubyLLM::Contract::Step::Base
   input_type Hash
 
   output_schema do
-    array :analyses do
-      string :action_item_id
-      string :status, enum: %w[clear ambiguous]
-      array :issues do
-        string :field, enum: %w[owner deadline scope]
-        string :problem
-        string :clarification_question
-      end
-    end
+    # Carry through the summary fields downstream consumers (and the next step) need.
+    string :tldr
+    array  :takeaways, of: :string
+    string :tone, enum: %w[neutral positive negative analytical]
+    # Add new field.
+    array  :hashtags, of: :string, min_items: 2, max_items: 5
   end
 
-  prompt <<~PROMPT
-    Review action items for completeness.
-    Flag vague owners, missing deadlines, unclear scope.
-
-    Action items: {action_items}
-  PROMPT
-
-  validate("all action items analyzed") do |output, input|
-    output[:analyses].map { |a| a[:action_item_id] }.sort ==
-      input[:action_items].map { |a| a[:id] }.sort
+  prompt do
+    rule "Preserve tldr / takeaways / tone exactly as given."
+    user "Article summary: {tldr}\nTone: {tone}\nGenerate 2 to 5 concise hashtags."
   end
+
+  validate("tone preserved") { |o, input| o[:tone] == input[:tone] }
 end
 
-# Step 3: Synthesize — the LLM is a "writer" producing a send-ready email
-class GenerateFollowUp < RubyLLM::Contract::Step::Base
+# Step 3 — final shape the UI card consumes.
+class BuildArticleCard < RubyLLM::Contract::Step::Base
   input_type Hash
 
   output_schema do
-    string :subject
-    string :body
-    integer :decisions_count
-    integer :action_items_count
+    string :headline
+    string :summary
+    array  :hashtags, of: :string
+    string :sentiment_icon, enum: %w[😐 🙂 ⚠️ 🧠]
   end
 
-  prompt <<~PROMPT
-    Write a follow-up email. List decisions, clear action items with owners
-    and deadlines, and embed clarification questions for ambiguous items.
+  prompt do
+    rule "Headline <= 70 chars. Summary is the incoming tldr reprinted verbatim."
+    rule "Pick sentiment_icon from: 😐 neutral, 🙂 positive, ⚠️ negative, 🧠 analytical."
+    user "TL;DR: {tldr}\nTone: {tone}\nHashtags: {hashtags}"
+  end
 
-    Decisions: {decisions}
-    Analyses: {analyses}
-  PROMPT
-
-  validate("subject must be concise") { |o| o[:subject].length <= 80 }
+  validate("summary is the tldr verbatim") { |o, input| o[:summary] == input[:tldr] }
 end
 
-# Pipeline: extract → analyze → email
-class MeetingFollowUp < RubyLLM::Contract::Pipeline::Base
-  step ExtractDecisions,    as: :extract
-  step ResolveAmbiguities,  as: :analyze
-  step GenerateFollowUp,    as: :email
+# Pipeline: summarize → hashtags → card
+class ArticleCardPipeline < RubyLLM::Contract::Pipeline::Base
+  step SummarizeArticle, as: :summarize
+  step GenerateHashtags, as: :tag
+  step BuildArticleCard, as: :card
 end
 ```
 
 ## Running and inspecting
 
 ```ruby
-result = MeetingFollowUp.run(transcript, context: { adapter: adapter })
+result = ArticleCardPipeline.run(article_text, context: { adapter: adapter })
 result.ok?                          # => true
-result.outputs_by_step[:extract]    # => {decisions: [...], action_items: [...]}
-result.outputs_by_step[:email]      # => {subject: "Follow-up: Q2 planning", body: "Hi team, ..."}
+result.outputs_by_step[:summarize]  # => { tldr: "...", takeaways: [...], tone: "analytical" }
+result.outputs_by_step[:card]       # => { headline: "...", summary: "...", hashtags: [...], sentiment_icon: "🧠" }
 result.trace.total_cost             # => 0.000128 (all steps combined)
 result.trace.total_latency_ms       # => 2340
 ```
@@ -107,38 +90,38 @@ result.trace.total_latency_ms       # => 2340
 Each step catches hallucinations before they spread:
 
 ```ruby
-result = MeetingFollowUp.run("just some random text")
-result.failed?                      # => true
-result.failed_step                  # => :extract (no real decisions found → stops here)
-# analyze and email never run — no hallucinated email goes out
+result = ArticleCardPipeline.run("")
+result.failed?        # => true
+result.failed_step    # => :summarize (empty input fails schema / validate → stops here)
+# tag and card never run — no downstream tokens spent on garbage
 ```
 
 ## Per-step model override
 
 ```ruby
-class EntityPipeline < RubyLLM::Contract::Pipeline::Base
-  step ExtractEntities,   as: :extract,   model: "gpt-4.1-nano"
-  step NormalizeEntities,  as: :normalize, model: "gpt-4.1-nano"
-  step ClassifyEntities,   as: :classify,  model: "gpt-4.1-mini"
+class ArticleCardPipeline < RubyLLM::Contract::Pipeline::Base
+  step SummarizeArticle, as: :summarize, model: "gpt-4.1-mini"
+  step GenerateHashtags, as: :tag,       model: "gpt-4.1-nano"
+  step BuildArticleCard, as: :card,      model: "gpt-4.1-nano"
 end
 ```
 
 ## Timeout
 
 ```ruby
-result = EntityPipeline.run("Apple released the iPhone.", timeout_ms: 30_000)
+result = ArticleCardPipeline.run(article_text, timeout_ms: 30_000)
 ```
 
 ## Pipeline eval
 
 ```ruby
-MeetingFollowUp.define_eval("e2e") do
-  add_case "quarterly planning transcript",
-    input: "Q2 planning meeting transcript: we decided...",
-    expected: { subject: /follow-up/i }
+ArticleCardPipeline.define_eval("e2e") do
+  add_case "ruby 3.4 release",
+    input: "Ruby 3.4 ships with frozen string literals by default and better YJIT...",
+    expected: { sentiment_icon: "🧠" }
 end
 
-report = MeetingFollowUp.run_eval("e2e", context: { model: "gpt-4.1-mini" })
+report = ArticleCardPipeline.run_eval("e2e", context: { model: "gpt-4.1-mini" })
 report.print_summary
 ```
 
@@ -158,5 +141,5 @@ report.print_summary
 
 ## See also
 
-- [Testing](testing.md) — `MeetingFollowUp.test(..., responses: { extract: ..., analyze: ..., email: ... })` for pipeline-level spec adapters.
+- [Testing](testing.md) — `ArticleCardPipeline.test(..., responses: { summarize: ..., tag: ..., card: ... })` for pipeline-level spec adapters.
 - [Optimizing retry_policy](optimizing_retry_policy.md) — `optimize_retry_policy` runs per-step; pipelines benchmark one step at a time.

--- a/docs/guide/pipeline.md
+++ b/docs/guide/pipeline.md
@@ -1,5 +1,7 @@
 # Pipeline
 
+> Read this when one step isn't enough — you need multi-step with fail-fast, automatic data threading, and per-step models.
+
 Chain multiple steps with automatic data threading, fail-fast, per-step models, trace, and timeout.
 
 A pipeline needs more than one step to be interesting. This guide grows the `SummarizeArticle` step from the [README](../../README.md) into a three-step content pipeline that tags and routes the summary to a UI card.

--- a/docs/guide/pipeline.md
+++ b/docs/guide/pipeline.md
@@ -89,12 +89,19 @@ result.trace.total_latency_ms       # => 2340
 
 ## Fail-fast behavior
 
-Each step catches hallucinations before they spread:
+When a step's schema, validate, or preflight check rejects the output, the pipeline stops there — downstream steps never run:
 
 ```ruby
-result = ArticleCardPipeline.run("")
+# Summarize returns a TL;DR over 200 chars → the "TL;DR fits the card" validate fails
+adapter = RubyLLM::Contract::Adapters::Test.new(response: {
+  tldr: "x" * 500,
+  takeaways: %w[one two three],
+  tone: "neutral"
+})
+
+result = ArticleCardPipeline.run("article text", context: { adapter: adapter })
 result.failed?        # => true
-result.failed_step    # => :summarize (empty input fails schema / validate → stops here)
+result.failed_step    # => :summarize (validate rejected; retries exhausted)
 # tag and card never run — no downstream tokens spent on garbage
 ```
 

--- a/docs/guide/pipeline.md
+++ b/docs/guide/pipeline.md
@@ -132,13 +132,13 @@ result = EntityPipeline.run("Apple released the iPhone.", timeout_ms: 30_000)
 ## Pipeline eval
 
 ```ruby
-TicketPipeline.define_eval("e2e") do
-  add_case "billing ticket",
-    input: "I was charged twice on my credit card",
-    expected: { subject: /billing/i }
+MeetingFollowUp.define_eval("e2e") do
+  add_case "quarterly planning transcript",
+    input: "Q2 planning meeting transcript: we decided...",
+    expected: { subject: /follow-up/i }
 end
 
-report = TicketPipeline.run_eval("e2e", context: { model: "gpt-4.1-mini" })
+report = MeetingFollowUp.run_eval("e2e", context: { model: "gpt-4.1-mini" })
 report.print_summary
 ```
 
@@ -155,3 +155,8 @@ result.pretty_print
 report.print_summary
 # Tabular pass/fail breakdown (Eval::Report)
 ```
+
+## See also
+
+- [Testing](testing.md) — `MeetingFollowUp.test(..., responses: { extract: ..., analyze: ..., email: ... })` for pipeline-level spec adapters.
+- [Optimizing retry_policy](optimizing_retry_policy.md) — `optimize_retry_policy` runs per-step; pipelines benchmark one step at a time.

--- a/docs/guide/prompt_ast.md
+++ b/docs/guide/prompt_ast.md
@@ -1,5 +1,7 @@
 # Prompt AST
 
+> Read this when your prompt has more than one shape (per-tenant, per-language, per-audience) and string concatenation is starting to drift.
+
 Prompts are structured data, not strings. That matters the moment `SummarizeArticle` has to ship in more than one shape — a different audience per tenant, a different language per region, a different tone template for a B2B vs consumer card. Building those variants by string-concatenating a monolithic prompt leads to silent drift across environments. The AST gives you typed nodes (`system`, `rule`, `section`, `example`, `user`) that compose, diff, and snapshot-test cleanly.
 
 Available node types:

--- a/docs/guide/prompt_ast.md
+++ b/docs/guide/prompt_ast.md
@@ -4,49 +4,65 @@ Prompts are structured data, not strings. Available node types:
 
 ```ruby
 prompt do
-  system "Main system instruction."          # system message
-  rule   "Return JSON only."                 # appended as separate system message
-  section "CONTEXT", "Product: Acme Inc."    # labeled system message: [CONTEXT]\n...
-  example input: "hello", output: "hi"       # user/assistant message pair
-  user   "Process this: {input}"             # user message with interpolation
+  system  "You summarize articles for a UI card."     # system message
+  rule    "Return valid JSON only."                   # appended as separate system message
+  section "AUDIENCE", "Rails developers"              # labeled system message: [AUDIENCE]\n...
+  example input:  "Ruby 3.4 ships frozen strings...", # user/assistant few-shot pair
+          output: '{"tldr":"...","takeaways":[...],"tone":"analytical"}'
+  user    "{input}"                                   # user message with interpolation
 end
 ```
 
-Or just a plain string (wraps as user message):
+Or just a plain string (wraps as a single user message):
 
 ```ruby
-prompt "Classify the intent of this text: {input}"
+prompt "Summarize this article for a UI card. {input}"
 ```
 
 The AST is immutable, diffable, and hashable. Useful for snapshot testing and auditing prompt changes.
 
 ## Hash inputs with variable interpolation
 
-When input is a Hash, each key becomes a template variable:
+When input is a Hash, each key becomes a template variable. For example, if `SummarizeArticle` evolves to accept explicit audience and language instead of raw article text:
 
 ```ruby
-class GenerateComment < RubyLLM::Contract::Step::Base
+class SummarizeArticle < RubyLLM::Contract::Step::Base
   input_type RubyLLM::Contract::Types::Hash.schema(
-    thread_title: RubyLLM::Contract::Types::String,
-    subreddit: RubyLLM::Contract::Types::String,
+    article:  RubyLLM::Contract::Types::String,
+    audience: RubyLLM::Contract::Types::String,
     language: RubyLLM::Contract::Types::String
   )
 
   prompt do
-    system "You are a helpful community member."
-    rule   "Write in {language}."
-    rule   "Stay on topic for r/{subreddit}."
-    user   "Thread: {thread_title}\n\nWrite a helpful comment."
+    system  "You summarize articles for a UI card."
+    rule    "Write the TL;DR and takeaways in {language}."
+    section "AUDIENCE", "{audience}"
+    user    "{article}"
+  end
+
+  output_schema do
+    string :tldr
+    array  :takeaways, of: :string, min_items: 3, max_items: 5
+    string :tone, enum: %w[neutral positive negative analytical]
   end
 end
 ```
 
+Every `{key}` in a prompt node is pulled from the input hash at run time. Missing keys raise — making wire-up bugs loud, not silent.
+
 ## Cross-validating output against input
 
-Validate blocks support 2-arity to compare output against input:
+Validate blocks support 2-arity `|output, input|` so you can check that the model's answer stays faithful to the request:
 
 ```ruby
-validate("all IDs must match input") do |output, input|
-  output.map { |r| r[:id] }.sort == input.map { |t| t[:id] }.sort
+validate("tldr is not just the article reprinted") do |output, input|
+  # Guard against lazy models that return the input verbatim.
+  output[:tldr].length < input[:article].length / 2
+end
+
+validate("no takeaway repeats the TL;DR") do |output, _input|
+  output[:takeaways].none? { |t| t == output[:tldr] }
 end
 ```
+
+The first example uses `input`; the second ignores it. Both are legal 2-arity signatures — Ruby accepts the unused `_input` parameter naming convention.

--- a/docs/guide/prompt_ast.md
+++ b/docs/guide/prompt_ast.md
@@ -1,6 +1,8 @@
 # Prompt AST
 
-Prompts are structured data, not strings. Available node types:
+Prompts are structured data, not strings. That matters the moment `SummarizeArticle` has to ship in more than one shape — a different audience per tenant, a different language per region, a different tone template for a B2B vs consumer card. Building those variants by string-concatenating a monolithic prompt leads to silent drift across environments. The AST gives you typed nodes (`system`, `rule`, `section`, `example`, `user`) that compose, diff, and snapshot-test cleanly.
+
+Available node types:
 
 ```ruby
 prompt do
@@ -23,7 +25,7 @@ The AST is immutable, diffable, and hashable. Useful for snapshot testing and au
 
 ## Hash inputs with variable interpolation
 
-When input is a Hash, each key becomes a template variable. For example, if `SummarizeArticle` evolves to accept explicit audience and language instead of raw article text:
+When input is a Hash, each key becomes a template variable. Concrete scenario: a multi-language newsletter product where the same article has to be summarised in Polish for EU subscribers, English for US, with different audiences per tier (Rails developers vs engineering managers). Hash inputs let one step cover all of these without forking the class:
 
 ```ruby
 class SummarizeArticle < RubyLLM::Contract::Step::Base

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -29,14 +29,14 @@ result = SummarizeArticle.run("article text", context: { adapter: adapter })
 result.ok?  # => true
 ```
 
-Multi-step pipeline testing with per-step named responses:
+Multi-step pipeline testing with per-step named responses (using `ArticleCardPipeline` from [Pipeline](pipeline.md)):
 
 ```ruby
-result = MyPipeline.test("input",
+result = ArticleCardPipeline.test("article text",
   responses: {
-    extract:  { decisions: [{ id: "D1", description: "ship", made_by: "lead" }] },
-    analyze:  { analyses: [{ action_item_id: "A1", status: "clear", issues: [] }] },
-    email:    { subject: "Follow-up", body: "Hi team, ..." }
+    summarize: { tldr: "...", takeaways: %w[a b c], tone: "analytical" },
+    tag:       { tldr: "...", takeaways: %w[a b c], tone: "analytical", hashtags: %w[#ruby #release] },
+    card:      { headline: "Ruby 3.4 ships", summary: "...", hashtags: %w[#ruby #release], sentiment_icon: "🧠" }
   }
 )
 ```
@@ -101,9 +101,9 @@ end
 ```ruby
 stub_steps(
   SummarizeArticle => { response: { tldr: "...", takeaways: %w[a b c], tone: "neutral" } },
-  RelatedArticles  => { response: { related: %w[article-1 article-2] } }
+  GenerateHashtags => { response: { tldr: "...", takeaways: %w[a b c], tone: "neutral", hashtags: %w[#ruby #release] } }
 ) do
-  result = ArticlePipeline.run("article text")
+  result = ArticleCardPipeline.run("article text")
 end
 ```
 

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -200,11 +200,20 @@ Log suspicious-but-not-invalid output without failing the contract:
 
 ```ruby
 class CompareArticles < RubyLLM::Contract::Step::Base
-  validate("scores in range") { |o| (1..10).include?(o[:score_a]) }
-  observe("scores should differ") { |o| o[:score_a] != o[:score_b] }
+  prompt "Score the article pair for relevance. Return JSON: {score_a: 1-10, score_b: 1-10}.\n\n{input}"
+
+  output_schema do
+    integer :score_a, minimum: 1, maximum: 10
+    integer :score_b, minimum: 1, maximum: 10
+  end
+
+  validate("scores in range") { |o, _| (1..10).cover?(o[:score_a]) && (1..10).cover?(o[:score_b]) }
+  observe("scores should differ") { |o, _| o[:score_a] != o[:score_b] }
 end
 
-result = CompareArticles.run(input)
+adapter = RubyLLM::Contract::Adapters::Test.new(response: { score_a: 5, score_b: 5 })
+result  = CompareArticles.run("two identical-looking articles", context: { adapter: adapter })
+
 result.ok?           # => true (observe never fails the contract)
 result.observations  # => [{ description: "scores should differ", passed: false }]
 ```

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -1,5 +1,7 @@
 # Testing
 
+CI that hits a real LLM on every commit is slow and costly: tests take minutes instead of milliseconds, every rerun spends money, and flakes on provider hiccups block merges. The Test adapter + `stub_step` make LLM-backed specs run like ordinary unit tests — deterministic, offline, free. Live evals stay as an opt-in CI stage for quality gating (see [Eval-First](eval_first.md)).
+
 How to write deterministic specs and matchers for steps built on `ruby_llm-contract`. Examples use `SummarizeArticle` (the flagship step from the [README](../../README.md)).
 
 ## Test adapter

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -34,9 +34,9 @@ Multi-step pipeline testing with per-step named responses:
 ```ruby
 result = MyPipeline.test("input",
   responses: {
-    extract:  { decisions: [...] },
-    analyze:  { analyses: [...] },
-    email:    { subject: "...", body: "..." }
+    extract:  { decisions: [{ id: "D1", description: "ship", made_by: "lead" }] },
+    analyze:  { analyses: [{ action_item_id: "A1", status: "clear", issues: [] }] },
+    email:    { subject: "Follow-up", body: "Hi team, ..." }
   }
 )
 ```
@@ -100,10 +100,10 @@ end
 
 ```ruby
 stub_steps(
-  SummarizeArticle => { response: { ... } },
-  RelatedArticles  => { response: { ... } }
+  SummarizeArticle => { response: { tldr: "...", takeaways: %w[a b c], tone: "neutral" } },
+  RelatedArticles  => { response: { related: %w[article-1 article-2] } }
 ) do
-  result = ArticlePipeline.run("...")
+  result = ArticlePipeline.run("article text")
 end
 ```
 

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -220,6 +220,32 @@ result.observations  # => [{ description: "scores should differ", passed: false 
 
 `observe` runs only after validation passes. Failed observations are logged via `RubyLLM::Contract.logger` — useful for "I want to know this happened without blocking the response".
 
+## Asserting on `around_call`
+
+`around_call` fires **once per run** with the final result (after retry fallback) and exceptions propagate. That makes it straightforward to test:
+
+```ruby
+class LoggedSummarize < RubyLLM::Contract::Step::Base
+  prompt "Summarize: {input}"
+  output_schema { string :tldr }
+
+  around_call do |_step, input, result|
+    CallLog.record(model: result.trace.model, cost: result.trace.cost, input_size: input.length)
+  end
+end
+
+RSpec.describe LoggedSummarize do
+  it "logs once per run, with final model + total cost" do
+    adapter = RubyLLM::Contract::Adapters::Test.new(response: { tldr: "ok" })
+    expect(CallLog).to receive(:record).once.with(hash_including(:model, :cost, :input_size))
+
+    LoggedSummarize.run("article text", context: { adapter: adapter })
+  end
+end
+```
+
+The callback receives `(step, input, result)` — the same `Result` the caller sees. Not invoked per-attempt inside a `retry_policy` chain; if you need per-attempt visibility, read `result.trace[:attempts]` inside the block.
+
 ## Baseline file format
 
 Baselines are JSON files in `.eval_baselines/` — commit them to git:

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -1,5 +1,7 @@
 # Testing
 
+> Read this when writing deterministic unit specs for contract steps. Skip if you only ever run live evals in CI and never stub LLM calls.
+
 CI that hits a real LLM on every commit is slow and costly: tests take minutes instead of milliseconds, every rerun spends money, and flakes on provider hiccups block merges. The Test adapter + `stub_step` make LLM-backed specs run like ordinary unit tests — deterministic, offline, free. Live evals stay as an opt-in CI stage for quality gating (see [Eval-First](eval_first.md)).
 
 How to write deterministic specs and matchers for steps built on `ruby_llm-contract`. Examples use `SummarizeArticle` (the flagship step from the [README](../../README.md)).

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -1,360 +1,231 @@
 # Testing
 
-## Test Adapter
+How to write deterministic specs and matchers for steps built on `ruby_llm-contract`. Examples use `SummarizeArticle` (the flagship step from the [README](../../README.md)).
 
-Ship deterministic specs with zero API calls. The adapter accepts String, Hash, or Array:
+## Test adapter
+
+Ships deterministic specs with zero API calls. Accepts a String, Hash, or Array:
 
 ```ruby
 # String JSON
-adapter = RubyLLM::Contract::Adapters::Test.new(response: '{"intent":"billing"}')
-
-# Hash — auto-converted to JSON
-adapter = RubyLLM::Contract::Adapters::Test.new(response: { intent: "billing" })
-
-# Multiple sequential responses
 adapter = RubyLLM::Contract::Adapters::Test.new(
-  responses: [{ intent: "billing" }, { intent: "sales" }]
+  response: '{"tldr":"...","takeaways":["a","b","c"],"tone":"neutral"}'
 )
 
-result = ClassifyIntent.run("Change my invoice", context: { adapter: adapter })
+# Hash — auto-converted to JSON
+adapter = RubyLLM::Contract::Adapters::Test.new(
+  response: { tldr: "...", takeaways: %w[a b c], tone: "neutral" }
+)
+
+# Multiple sequential responses (one per call)
+adapter = RubyLLM::Contract::Adapters::Test.new(
+  responses: [
+    { tldr: "...", takeaways: %w[a b c], tone: "neutral" },
+    { tldr: "...", takeaways: %w[x y z], tone: "analytical" }
+  ]
+)
+
+result = SummarizeArticle.run("article text", context: { adapter: adapter })
 result.ok?  # => true
 ```
 
-Multi-step pipeline testing with named responses:
+Multi-step pipeline testing with per-step named responses:
 
 ```ruby
 result = MyPipeline.test("input",
   responses: {
     extract:  { decisions: [...] },
     analyze:  { analyses: [...] },
-    email:    { subject: "Follow-up", body: "..." }
+    email:    { subject: "...", body: "..." }
   }
 )
 ```
 
 ## Output keys are always symbols
 
-Parsed output uses **symbol keys**, never string keys:
+Parsed output uses **symbol keys**, never strings:
 
 ```ruby
-result.parsed_output[:priority]   # => "high" ✓
-result.parsed_output["priority"]  # => nil ✗
+result.parsed_output[:tldr]     # => "..." ✓
+result.parsed_output["tldr"]    # => nil ✗
 ```
 
-The gem warns if a `validate` or `verify` block returns `nil` — usually a sign of string key access on symbolized data.
+The gem warns if a `validate` or `verify` block returns `nil` — usually a sign of string-key access on symbol-keyed data.
 
-## RSpec Setup
+## RSpec setup
 
-Add to your `spec_helper.rb`:
+In `spec_helper.rb`:
 
 ```ruby
 require "ruby_llm/contract/rspec"
 ```
 
-This gives you: `satisfy_contract`, `pass_eval` matchers, and the `stub_step` helper.
+You get the `satisfy_contract` matcher, `pass_eval` matcher, and the `stub_step` helpers.
 
-## stub_step Helper
+## stub_step helpers
 
-Stubs a specific step to return a canned response. Other steps are unaffected:
+`stub_step` canned-responses a single step; other steps run normally.
 
 ```ruby
-RSpec.describe ClassifyIntent do
-  before { stub_step(described_class, response: { intent: "billing" }) }
+RSpec.describe SummarizeArticle do
+  before { stub_step(described_class, response: { tldr: "...", takeaways: %w[a b c], tone: "neutral" }) }
 
-  it "satisfies contract" do
-    result = described_class.run("Change my invoice")
+  it "satisfies its contract" do
+    result = described_class.run("article text")
     expect(result).to satisfy_contract
   end
 end
 ```
 
-For multiple responses:
+**Sequential responses:**
+
 ```ruby
-stub_step(described_class, responses: [{ intent: "billing" }, { intent: "sales" }])
+stub_step(described_class, responses: [
+  { tldr: "...", takeaways: %w[a b c], tone: "neutral" },
+  { tldr: "...", takeaways: %w[x y z], tone: "analytical" }
+])
 ```
 
-### Block form (auto-cleanup)
-
-Stub is scoped to the block — automatically cleaned up after:
+**Block form (auto-cleanup):**
 
 ```ruby
-stub_step(ClassifyTicket, response: { priority: "high" }) do
-  result = ClassifyTicket.run("test")
-  # stub active here
+stub_step(SummarizeArticle, response: { tldr: "...", takeaways: %w[a b c], tone: "neutral" }) do
+  result = SummarizeArticle.run("article text")
+  # stub is active here
 end
-# stub gone — original behavior restored
+# stub gone — original adapter restored
 ```
 
-### Multiple steps at once
-
-`stub_steps` stubs multiple steps with different responses in one block:
+**Multiple steps at once:**
 
 ```ruby
 stub_steps(
-  ClassifyTicket => { response: { priority: "high" } },
-  RouteToTeam => { response: { team: "billing" } }
+  SummarizeArticle => { response: { ... } },
+  RelatedArticles  => { response: { ... } }
 ) do
-  result = TicketPipeline.run("I was charged twice")
+  result = ArticlePipeline.run("...")
 end
 ```
 
-### Global stub
+**Global stub for all steps:**
 
-To stub ALL steps globally:
 ```ruby
 stub_all_steps(response: { default: true })
 ```
 
-In RSpec, non-block stubs are auto-cleaned after each example. In Minitest, `teardown` restores the original adapter automatically (via `MinitestHelpers`).
+In RSpec, non-block stubs auto-clean after each example. In Minitest, `teardown` restores the original adapter (via `MinitestHelpers`).
 
-## RSpec Matchers
+## Minitest
+
+Require `ruby_llm/contract/minitest` in your `test_helper.rb`. You get the same `satisfy_contract` / `pass_eval` assertions and `stub_step` helper, adapted for Minitest syntax.
+
+## RSpec matchers
 
 ```ruby
-RSpec.describe ClassifyIntent do
-  before { stub_step(described_class, response: { intent: "billing" }) }
+RSpec.describe SummarizeArticle do
+  before { stub_step(described_class, response: { tldr: "...", takeaways: %w[a b c], tone: "neutral" }) }
 
-  it "satisfies contract" do
-    result = described_class.run("Change my invoice")
+  it "satisfies its contract" do
+    result = described_class.run("article text")
     expect(result).to satisfy_contract
   end
 
-  it "catches invalid output" do
-    stub_step(described_class, response: { intent: "unknown" })
-    result = described_class.run("hello")
-    expect(result).not_to satisfy_contract
+  it "rejects invalid output" do
+    stub_step(described_class, response: { tldr: "x" * 300, takeaways: %w[a b c], tone: "neutral" })
+    result = described_class.run("article text")
+    expect(result).not_to satisfy_contract  # TL;DR > 200 chars fails validate
   end
 
-  it "passes eval" do
+  it "passes its eval" do
     expect(described_class).to pass_eval("smoke")
   end
 end
 ```
 
-## Offline vs Online Eval
+`pass_eval` supports a matcher chain — full reference lives in [Getting Started](getting_started.md) under Evals and CI gates. Quick summary:
 
-Evals run in two modes depending on how the eval is defined and what context is passed:
+- `.with_context(model: "gpt-4.1-mini")` — pick model / pass adapter
+- `.with_minimum_score(0.8)` — gate on average score
+- `.with_maximum_cost(0.01)` — gate on total cost
+- `.without_regressions` — block any previously-passing case that now fails (reads the baseline)
+- `.compared_with(SummarizeArticleV1)` — A/B against another step; implies regression check
 
-| Has `sample_response`? | Context has adapter? | Mode | API calls |
-|------------------------|---------------------|------|-----------|
-| Yes | No | **Offline** — uses sample_response as canned answer | Zero |
-| Yes | Yes | **Online** — ignores sample_response, calls real LLM | Real |
+## Offline vs online eval
+
+Evals run in one of two modes depending on how they're defined and what context is passed:
+
+| Has `sample_response`? | Context has adapter/model? | Mode | API calls |
+|---|---|---|---|
+| Yes | No | **Offline** — uses `sample_response` as canned answer | Zero |
+| Yes | Yes | **Online** — ignores `sample_response`, calls real LLM | Real |
 | No | Yes | **Online** — calls real LLM | Real |
 | No | No | **Skipped** — returns `:skipped`, excluded from score | Zero |
 
-**Default is offline.** If your eval has `sample_response`, `run_eval` uses it as a test adapter automatically. No API key needed.
-
-**To force online:** pass adapter or model in context:
-```ruby
-# Online — calls real LLM
-report = Step.run_eval("regression", context: { model: "gpt-4.1-nano" })
-
-# Offline — uses sample_response (default)
-report = Step.run_eval("smoke")
-```
-
-**In Rake task:**
-```ruby
-RubyLLM::Contract::RakeTask.new do |t|
-  # Without context: runs offline (sample_response)
-  # With context: runs online
-  t.context = { model: "gpt-4.1-nano" }  # online
-end
-```
-
-## Eval with Test Cases
-
-`add_case` inside `define_eval` for dataset-driven evaluation:
+Default is offline. To force online, pass adapter or model in context:
 
 ```ruby
-ClassifyTicket.define_eval("regression") do
-  add_case "billing", input: "I was charged twice", expected: { priority: "high" }
-  add_case "feature", input: "Add dark mode", expected: { priority: "low" }
-end
+# Online — real LLM call
+report = SummarizeArticle.run_eval("regression", context: { model: "gpt-4.1-nano" })
+
+# Offline — uses sample_response
+report = SummarizeArticle.run_eval("smoke")
 ```
 
-Each case runs the step and compares the output against `expected`. Fields in `expected` are matched by key -- extra output keys are ignored.
+`compare_with` intentionally ignores `sample_response` because canned data would make both sides look identical. Always pass `model:` or an adapter to A/B.
 
-Set a shared input with `default_input` when all cases share the same shape:
+## Inspecting failures
+
+`run_eval` returns a `Report`. Drill into per-case failures:
 
 ```ruby
-ClassifyTicket.define_eval("regression") do
-  default_input "I was charged twice"
-  add_case "detects billing", expected: { category: "billing" }
-  add_case "high priority",  expected: { priority: "high" }
-end
-```
-
-## Threshold-Based Gating
-
-Chain `.with_minimum_score` and `.with_maximum_cost` onto `pass_eval` to set acceptance thresholds:
-
-```ruby
-expect(ClassifyTicket).to pass_eval("regression")
-  .with_context(model: "gpt-4.1-mini")
-  .with_minimum_score(0.8)
-  .with_maximum_cost(0.01)
-```
-
-- `with_minimum_score(0.8)` -- pass if average score >= 0.8 (default requires 1.0)
-- `with_maximum_cost(0.01)` -- fail if total cost exceeds $0.01
-
-Both constraints must hold for the matcher to pass.
-
-## Rake Task
-
-Run all evals from the command line with a Rake task:
-
-```ruby
-# Rakefile
-require "ruby_llm/contract/rake_task"
-
-RubyLLM::Contract::RakeTask.new do |t|
-  t.minimum_score = 0.8
-  t.maximum_cost = 0.05
-  t.track_history = true       # auto-append every run to .eval_history/
-  t.fail_on_regression = true  # block if previously-passing case now fails
-  t.save_baseline = true       # save baseline after green run
-end
-```
-
-```sh
-rake ruby_llm_contract:eval
-```
-
-The task discovers every `define_eval` across your steps, runs them, and aborts if any threshold is breached. In Rails apps it automatically depends on `:environment`.
-
-## Inspecting Failures
-
-`run_eval` returns a `Report`. Drill into failures for programmatic assertions or debugging:
-
-```ruby
-report = ClassifyTicket.run_eval("regression")
+report = SummarizeArticle.run_eval("regression")
 
 report.score       # => 0.5
 report.pass_rate   # => "1/2"
 report.total_cost  # => 0.003
 
 report.failures.each do |result|
-  puts result.name       # => "feature"
-  puts result.mismatches # => { priority: { expected: "low", got: "medium" } }
-  puts result.output     # full parsed output hash
-  puts result.details    # human-readable explanation
+  puts result.name        # => "critical review"
+  puts result.mismatches  # => { tone: { expected: "negative", got: "analytical" } }
+  puts result.output      # full parsed output hash
+  puts result.details     # human-readable explanation
 end
 ```
 
-`mismatches` returns a hash of keys where `expected` and actual output diverge -- handy for pinpointing which field a model got wrong.
+`mismatches` is a hash of keys where expected and actual output diverge — pinpoints which field the model got wrong.
 
-## Baseline Regression Detection
-
-Like `schema.rb` for your LLM quality — save what works, catch when it breaks.
-
-```ruby
-# First run — everything passes, save as baseline
-report = ClassifyTicket.run_eval("regression", context: { model: "gpt-4.1-nano" })
-report.save_baseline!(model: "gpt-4.1-nano")
-# Writes to .eval_baselines/ClassifyTicket/regression_gpt-4_1-nano.json
-```
-
-Later — after a prompt change, model update, or provider weight shift:
-
-```ruby
-report = ClassifyTicket.run_eval("regression", context: { model: "gpt-4.1-nano" })
-diff = report.compare_with_baseline(model: "gpt-4.1-nano")
-
-diff.regressed?      # => true
-diff.regressions     # => [{case: "outage", baseline: {passed: true}, current: {passed: false}}]
-diff.improvements    # => []
-diff.score_delta     # => -0.33
-diff.new_cases       # => cases added since baseline
-diff.removed_cases   # => cases removed since baseline (treated as regression if passing)
-```
-
-### CI gate on regressions
-
-```ruby
-# RSpec — block merge if any previously-passing case now fails
-expect(ClassifyTicket).to pass_eval("regression")
-  .with_context(model: "gpt-4.1-nano")
-  .without_regressions
-```
-
-```ruby
-# Rake — auto-save baseline after green, fail on regression
-RubyLLM::Contract::RakeTask.new do |t|
-  t.minimum_score = 0.8
-  t.fail_on_regression = true
-  t.save_baseline = true
-end
-```
-
-### What counts as a regression
-
-- A case that **passed** in baseline but **fails** now
-- A case that **passed** in baseline but is **missing** from current eval (removed or skipped)
-- Score drop alone is NOT a regression — use `with_minimum_score` for that
-
-## Prompt A/B Testing
-
-Compare two prompts side-by-side with regression safety:
-
-```ruby
-diff = ClassifyTicketV2.compare_with(ClassifyTicketV1,
-  eval: "regression", model: "gpt-4.1-mini")
-
-diff.safe_to_switch?    # => true (no regressions, no score drop, identical cases)
-diff.improvements       # => [{case: "outage", ...}]
-diff.regressions        # => []
-diff.score_delta        # => +0.33
-diff.score_regressions  # => per-case score drops
-```
-
-`safe_to_switch?` enforces:
-- Both sides have evaluated cases (no empty/skipped)
-- Identical case names, inputs, AND expected values (no dataset manipulation)
-- No pass→fail regressions or removed passing cases
-- No per-case score drops (even if the average stays flat)
-
-**Important:** `compare_with` requires a real adapter or model — it will NOT use `sample_response`. A/B testing with canned data gives identical results for both sides. Pass `model:` for real LLM calls, or explicit test adapters per step for deterministic tests.
-
-### CI gate for prompt changes
-
-```ruby
-# Block merge if new prompt regresses any case
-expect(ClassifyTicketV2).to pass_eval("regression")
-  .compared_with(ClassifyTicketV1)
-  .with_minimum_score(0.8)
-```
-
-`compared_with` implies regression check — `.without_regressions` is optional.
-
-## Soft Observations
+## Soft observations
 
 Log suspicious-but-not-invalid output without failing the contract:
 
 ```ruby
-class EvaluateComparative < RubyLLM::Contract::Step::Base
+class CompareArticles < RubyLLM::Contract::Step::Base
   validate("scores in range") { |o| (1..10).include?(o[:score_a]) }
   observe("scores should differ") { |o| o[:score_a] != o[:score_b] }
 end
 
-result = EvaluateComparative.run(input)
-result.ok?            # => true (observe never fails)
-result.observations   # => [{description: "scores should differ", passed: false}]
+result = CompareArticles.run(input)
+result.ok?           # => true (observe never fails the contract)
+result.observations  # => [{ description: "scores should differ", passed: false }]
 ```
 
-Observations run only when validation passes. Failed observations are logged via `Contract.logger`.
+`observe` runs only after validation passes. Failed observations are logged via `RubyLLM::Contract.logger` — useful for "I want to know this happened without blocking the response".
 
-### Baseline file format
+## Baseline file format
 
-Baselines are JSON files in `.eval_baselines/` — add to git:
+Baselines are JSON files in `.eval_baselines/` — commit them to git:
 
 ```
 .eval_baselines/
-  ClassifyTicket/
+  SummarizeArticle/
     regression_gpt-4_1-nano.json
     regression_gpt-4_1-mini.json
-  EvaluatePersona/
-    smoke.json
 ```
 
-Each file contains dataset name, step name, score, and per-case results. No timestamps — re-saving an identical baseline produces no git diff.
+Each file contains dataset name, step name, score, and per-case results. No timestamps — re-saving an identical baseline produces no git diff. Baseline semantics (what counts as a regression, how `compare_with_baseline` works) are covered in [Getting Started](getting_started.md#evals-and-ci-gates) and [Eval-First](eval_first.md).
+
+## See also
+
+- [Getting Started](getting_started.md) — `pass_eval` matcher chain, threshold gating, Rake task, baseline regressions.
+- [Eval-First](eval_first.md) — `compare_with` prompt A/B workflow.
+- [Pipeline](pipeline.md) — pipeline-level testing with named step responses.

--- a/docs/guide/why.md
+++ b/docs/guide/why.md
@@ -1,0 +1,97 @@
+# Why contracts?
+
+> Read this if you're not sure whether `ruby_llm-contract` solves a problem you actually have. It's the fastest way to recognise the production failure modes the gem exists for.
+
+LLMs return JSON that *looks* correct — valid shape, right types, right fields — while being silently wrong in ways that hurt users, burn budget, or break downstream code. Schema validation alone does not catch these. Contracts layer on business rules, retries, evals, and cost caps so the wrong output is caught at the boundary of your system instead of shipping to production.
+
+Below are four failure modes teams actually hit. If one looks familiar, the gem is probably worth 30 minutes of your time.
+
+## Failure 1 — Schema-valid, logically wrong
+
+A `SummarizeArticle` step produces `{ tldr: "...", takeaways: [...], tone: "analytical" }`. Schema passes. The TL;DR is 520 characters long and overflows the UI card. Or the takeaways are all variations of the same sentence. Or the article was a service-outage complaint and `tone` came back `"analytical"` instead of `"negative"` — so customer success's "critical feedback" filter never sees it.
+
+JSON schema enforces **shape**. It cannot enforce *length fits the card*, *takeaways are distinct*, or *tone matches content*. Those are business rules, and without them you find out from a Slack thread or a support ticket.
+
+```ruby
+validate("TL;DR fits the card")  { |o, _| o[:tldr].length <= 200 }
+validate("takeaways are unique") { |o, _| o[:takeaways].uniq.size == o[:takeaways].size }
+validate("negative tone requires concrete risk") do |o, _|
+  next true unless o[:tone] == "negative"
+  o[:takeaways].any? { |t| t.match?(/fail|break|crash|outage|risk/i) }
+end
+```
+
+Wrong output never reaches `Article.update!` — the contract refuses before it persists.
+
+## Failure 2 — Silent prompt regression
+
+`SummarizeArticle` ships and works. Two weeks later, someone tweaks the system prompt to emphasise negative sentiment because customer success complained about missed complaints. The tweak fixes that case and silently breaks three neutral product-update articles that now get labelled `"negative"`. Nobody knows for a week.
+
+Without evals, *every prompt change is a blind deploy.* Contracts invert this:
+
+```ruby
+SummarizeArticle.define_eval("regression") do
+  add_case "outage complaint", input: "...", expected: { tone: "negative" }
+  add_case "neutral product update", input: "...", expected: { tone: "neutral" }
+end
+
+# In CI — blocks merge when a prompt tweak regresses any previously-passing case
+expect(SummarizeArticle).to pass_eval("regression").without_regressions
+```
+
+The "tweak helped one case, broke three" scenario is caught at PR review. No Slack-thread surprises.
+
+## Failure 3 — Refusal as valid JSON
+
+Cheap models sometimes refuse to answer, and they do it in-schema. `gpt-4.1-nano` happily returns `{ "tldr": "I cannot help with that request.", "takeaways": ["Please provide more context", "I need more information", "Unable to summarize"], "tone": "neutral" }`. Every field is the right type. Schema passes. You ship a UI card that apologises to the user.
+
+Validates + retry with model fallback turn this from a silent ship into an automatic recovery:
+
+```ruby
+validate("not a refusal") do |o, _|
+  !o[:tldr].match?(/i (cannot|can't|am unable)/i) &&
+    o[:takeaways].none? { |t| t.match?(/please provide|more context|unable to/i) }
+end
+
+retry_policy models: %w[gpt-4.1-nano gpt-4.1-mini gpt-4.1]
+```
+
+Nano refuses → contract rejects → mini gets the call. The user never sees the refusal. Your logs show the retry and the cost.
+
+## Failure 4 — Runaway cost and no fallback policy
+
+Someone pastes a 40-page PDF into the endpoint that calls `SummarizeArticle`. The prompt expands to 80k tokens. Your provider bill jumps. Meanwhile, a separate team uses `gpt-4.1` for every single call because "quality matters" — even though 80% of their traffic is trivially handled by `gpt-4.1-nano` at 1/30th the cost. Neither situation is visible until the invoice arrives.
+
+Contracts make cost a first-class concern:
+
+```ruby
+max_input  2_000   # refuses before calling the API if tokens exceed budget
+max_output 4_000
+max_cost   0.01    # refuses if estimated cost exceeds cap
+retry_policy models: %w[gpt-4.1-nano gpt-4.1-mini gpt-4.1]  # cheap first, escalate only on failure
+```
+
+The 40-page PDF returns `status: :limit_exceeded` — zero tokens spent. The 80/20 traffic pattern resolves on nano; only the hard 20% escalate. [`optimize_retry_policy`](optimizing_retry_policy.md) tells you empirically which fallback list is cheapest for *your* evals.
+
+## Also catches
+
+- **Leaked prompt placeholders** — model echoes `{article}` or `{audience}` into the output because the template string wasn't interpolated. Validate string-equality check stops it before a user sees it.
+- **Lazy models echoing input verbatim** — cheap model returns the article text as the "summary". 2-arity `validate("tldr shorter than input")` catches it.
+- **Tone mislabel breaking downstream routing** — content says "negative", model labels it "analytical", a customer success filter misses it. Cross-validate catches the label/content drift.
+
+## Failure → contract mechanism
+
+| Failure in production | Contract mechanism |
+|---|---|
+| Schema-valid but logically wrong output | `validate(...) { |o, i| ... }` with 2-arity for cross-checks |
+| Silent prompt regression after a tweak | `define_eval` + `pass_eval(...).without_regressions` in CI |
+| Cheap model refuses in-schema | `validate("not a refusal")` + `retry_policy models: [...]` |
+| Runaway cost on pathological inputs | `max_input`, `max_output`, `max_cost` preflight |
+| 80/20 traffic paying the premium model rate | `retry_policy` + `optimize_retry_policy` |
+| Leaked placeholder / input echo / tone drift | `validate` with content and cross-input checks |
+
+## What next
+
+- **If one of the failures above looks familiar** → [Getting Started](getting_started.md) walks through every feature in order on the same `SummarizeArticle` step.
+- **If you're adopting in an existing Rails app** → [Migration](migration.md) shows Before/After for replacing a raw `LlmClient.new.call` service.
+- **If you already ship LLM features and want to make them regression-safe** → [Eval-First](eval_first.md) is the workflow that prevents Failure 2 from ever happening again.

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,11 +9,11 @@ Step-by-step tutorial covering every feature. Start here.
 | 1 | Plain string prompt | Simplest case — `user "{input}"` and nothing else |
 | 2 | System + user | Separate instructions from data |
 | 3 | Rules + output_schema | Requirements as statements + declarative output structure |
-| 4 | Invariants | Custom business logic on top of schema |
+| 4 | Validate blocks | Custom business logic on top of schema |
 | 5 | Examples | Few-shot (example input/output pairs) |
 | 6 | Sections | Labeled context blocks (heredoc replacement, with before/after) |
 | 7 | Hash input | Multiple fields with auto-interpolation |
-| 8 | 2-arity invariants | Cross-validate output against input |
+| 8 | 2-arity validates | Cross-validate output against input |
 | 9 | Context override | Per-run adapter and model switching |
 | 10 | StepResult | Full inspection: status, output, errors, trace |
 | 11 | Pipeline | Chain steps with fail-fast data threading |
@@ -23,17 +23,17 @@ Every step has a corresponding test in `spec/integration/examples_00_basics_spec
 ## 01_classify_threads.rb — Thread classification
 
 Real-world before/after: classify Reddit threads as PROMO/FILLER/SKIP.
-Shows ID matching, enum validation, score consistency invariants.
+Shows ID matching, enum validation, score consistency validates.
 
 ## 02_generate_comment.rb — Comment generation
 
 Real-world before/after: generate Reddit comments with persona.
-Shows sections, banned openings, link presence, length constraints, 2-arity invariants.
+Shows sections, banned openings, link presence, length constraints, 2-arity validates.
 
 ## 03_target_audience.rb — Audience profiling
 
 Real-world before/after: generate target audience profiles.
-Shows cascade failure prevention, locale validation, structural invariants.
+Shows cascade failure prevention, locale validation, cross-field validates.
 
 ## 04_real_llm.rb — Real LLM calls via ruby_llm
 
@@ -57,13 +57,13 @@ Shows configuration, model switching, temperature/max_tokens control, provider-a
 
 ## 05_output_schema.rb — Declarative output schema
 
-Replace manual invariants with a schema DSL (ruby_llm-schema).
+Replace manual validate blocks with a schema DSL (ruby_llm-schema).
 
 | Step | Feature | What it shows |
 |------|---------|---------------|
-| 1 | Before (invariants) | Manual enum, range, required checks |
+| 1 | Before (validates) | Manual enum, range, required checks |
 | 2 | After (schema) | Same constraints in declarative DSL |
-| 3 | Schema + invariants | Schema for structure, invariants for business logic |
+| 3 | Schema + validates | Schema for structure, validates for business logic |
 | 4 | Complex schema | Nested objects, arrays, constraints |
 | 5 | Provider-agnostic | Same schema works with Test and RubyLLM adapters |
 | 6 | Pipeline + schemas | Fully typed multi-step composition |
@@ -86,7 +86,7 @@ ruby examples/04_real_llm.rb
 
 3-step pipeline from the reddit_promo_planner case study:
 
-| Step | Role | Invariants catch |
+| Step | Role | Validates catch |
 |------|------|------------------|
 | 1 | TargetAudience | `locale: "USA"` instead of `"en"`, vague summary |
 | 2 | ClassifyThreads | PROMO with score 2, SKIP with score 8 |
@@ -102,8 +102,8 @@ Extract up to 15 keywords from an article, each with relevance probability.
 |---------|---------------|
 | Array schema | `min_items: 1, max_items: 15` with nested objects |
 | Number range | `probability: 0.0–1.0` |
-| Sorting invariant | Schema can't express "sorted descending" |
-| Uniqueness invariant | Schema can't express "no duplicates" |
+| Sort validate | Schema can't express "sorted descending" |
+| Uniqueness validate | Schema can't express "no duplicates" |
 | Cross-validation | Keywords must appear in source text (catches hallucination) |
 | Pipeline | Keywords → Related Topics |
 
@@ -111,7 +111,7 @@ Extract up to 15 keywords from an article, each with relevance probability.
 
 3-step pipeline: extract segments → translate → review quality.
 
-| Step | LLM Skill | Invariants catch |
+| Step | LLM Skill | Validates catch |
 |------|-----------|------------------|
 | Extract | Analysis | Duplicate keys, wrong target_lang |
 | Translate | Creative | Missing segments, too long, echoed back untranslated |

--- a/examples/README.md
+++ b/examples/README.md
@@ -82,18 +82,6 @@ ruby examples/05_output_schema.rb
 ruby examples/04_real_llm.rb
 ```
 
-## 06_reddit_promo.rb — Real-world Reddit promo pipeline
-
-3-step pipeline from the reddit_promo_planner case study:
-
-| Step | Role | Validates catch |
-|------|------|------------------|
-| 1 | TargetAudience | `locale: "USA"` instead of `"en"`, vague summary |
-| 2 | ClassifyThreads | PROMO with score 2, SKIP with score 8 |
-| 3 | GenerateComment | `{PRODUCT}` instead of URL, banned openings |
-
-Runs with test adapter by default. `REAL_LLM=1` for Ollama, `MODEL=gemma:latest` to pick model.
-
 ## 07_keyword_extraction.rb — Keyword extraction with probability
 
 Extract up to 15 keywords from an article, each with relevance probability.
@@ -117,6 +105,14 @@ Extract up to 15 keywords from an article, each with relevance probability.
 | Translate | Creative | Missing segments, too long, echoed back untranslated |
 | Review | Evaluation | Inconsistent counts, failed reviews without issues |
 
+## 09_eval_dataset.rb — Dataset-driven eval workflow
+
+Shows `define_eval` + `add_case` + `compare_models` end-to-end against a small hand-curated dataset.
+
+## 10_reddit_full_showcase.rb — Full showcase across the gem
+
+Multi-step pipeline exercising schema, validates, retry with fallback, evals, and baseline regression detection on a single realistic case.
+
 ## Running
 
 ```bash
@@ -126,15 +122,14 @@ ruby examples/01_classify_threads.rb
 ruby examples/02_generate_comment.rb
 ruby examples/03_target_audience.rb
 ruby examples/05_output_schema.rb
-ruby examples/06_reddit_promo.rb
 ruby examples/07_keyword_extraction.rb
 ruby examples/08_translation.rb
+ruby examples/09_eval_dataset.rb
+ruby examples/10_reddit_full_showcase.rb
 
 # Real LLM — requires Ollama or API key:
 ruby examples/04_real_llm.rb
-REAL_LLM=1 ruby examples/06_reddit_promo.rb
-REAL_LLM=1 MODEL=llama3.2:3b ruby examples/06_reddit_promo.rb
 ```
 
-Examples 00–03, 05–06 use the test adapter by default — no API keys needed.
-Example 04 and 06 with `REAL_LLM=1` require Ollama or an API key.
+Examples 00–03, 05, 07–10 use the test adapter by default — no API keys needed.
+Example 04 requires an API key.

--- a/lib/ruby_llm/contract/eval/model_comparison.rb
+++ b/lib/ruby_llm/contract/eval/model_comparison.rb
@@ -72,9 +72,9 @@ module RubyLLM
           end
 
           chain_width = [rows.map { |r| r[:chain].length }.max || 0, 20].max
-          lines = [format("  %-#{chain_width}s  %-12s  %-10s  %-14s  %-9s  %s",
+          lines = [format("  %-#{chain_width}s  %-13s  %-10s  %-14s  %-9s  %s",
                           "Chain", "first-attempt", "fallback %", "effective cost", "latency", "score")]
-          lines << "  #{"-" * (chain_width + 60)}"
+          lines << "  #{"-" * (chain_width + 62)}"
 
           rows.each do |row|
             lines << format_production_row(row, chain_width)
@@ -95,7 +95,7 @@ module RubyLLM
 
         def format_production_row(row, chain_width)
           report = row[:report]
-          format("  %-#{chain_width}s  %-11s  %-10s  %-14s  %-9s  %6.2f",
+          format("  %-#{chain_width}s  %-13s  %-10s  %-14s  %-9s  %6.2f",
                  row[:chain],
                  format_money(report.single_shot_cost || report.total_cost),
                  format_escalation(row, report),

--- a/lib/ruby_llm/contract/eval/model_comparison.rb
+++ b/lib/ruby_llm/contract/eval/model_comparison.rb
@@ -72,8 +72,8 @@ module RubyLLM
           end
 
           chain_width = [rows.map { |r| r[:chain].length }.max || 0, 20].max
-          lines = [format("  %-#{chain_width}s  %-11s  %-10s  %-14s  %-9s  %s",
-                          "Chain", "single-shot", "escalation", "effective cost", "latency", "score")]
+          lines = [format("  %-#{chain_width}s  %-12s  %-10s  %-14s  %-9s  %s",
+                          "Chain", "first-attempt", "fallback %", "effective cost", "latency", "score")]
           lines << "  #{"-" * (chain_width + 60)}"
 
           rows.each do |row|

--- a/lib/ruby_llm/contract/eval/retry_optimizer.rb
+++ b/lib/ruby_llm/contract/eval/retry_optimizer.rb
@@ -20,7 +20,7 @@ module RubyLLM
           alias_method :hardest_eval, :constraining_eval
 
           def print_summary(io = $stdout)
-            io.puts "#{step_name} — retry chain optimization"
+            io.puts "#{step_name} — fallback list optimization"
             io.puts
             print_table(io)
             io.puts

--- a/lib/ruby_llm/contract/eval/retry_optimizer.rb
+++ b/lib/ruby_llm/contract/eval/retry_optimizer.rb
@@ -15,6 +15,10 @@ module RubyLLM
       class RetryOptimizer
         Result = Struct.new(:step_name, :eval_names, :candidate_labels, :score_matrix,
                             :constraining_eval, :chain, :chain_details, keyword_init: true) do
+          # Terminology alias — `hardest_eval` is the narrative name used in docs;
+          # `constraining_eval` is preserved as the original field name.
+          alias_method :hardest_eval, :constraining_eval
+
           def print_summary(io = $stdout)
             io.puts "#{step_name} — retry chain optimization"
             io.puts
@@ -59,7 +63,7 @@ module RubyLLM
             end
 
             io.puts
-            io.puts "  Constraining eval: #{constraining_eval}" if constraining_eval
+            io.puts "  Hardest eval: #{constraining_eval}" if constraining_eval
           end
 
           def print_chain(io)
@@ -68,7 +72,7 @@ module RubyLLM
               return
             end
 
-            io.puts "  Suggested chain:"
+            io.puts "  Suggested fallback list:"
             chain_details.each_with_index do |detail, i|
               suffix = i == chain_details.size - 1 ? "passes all #{eval_names.size} evals" : "covers #{detail[:passes]} eval(s)"
               io.puts "    #{detail[:label]} — #{suffix}"

--- a/lib/ruby_llm/contract/version.rb
+++ b/lib/ruby_llm/contract/version.rb
@@ -2,6 +2,6 @@
 
 module RubyLLM
   module Contract
-    VERSION = "0.7.1"
+    VERSION = "0.7.2"
   end
 end

--- a/spec/ruby_llm/contract/eval/retry_optimizer_spec.rb
+++ b/spec/ruby_llm/contract/eval/retry_optimizer_spec.rb
@@ -284,8 +284,8 @@ RSpec.describe RubyLLM::Contract::Eval::RetryOptimizer do
       text = output.string
 
       expect(text).to include("retry chain optimization")
-      expect(text).to include("Constraining eval: hard")
-      expect(text).to include("Suggested chain:")
+      expect(text).to include("Hardest eval: hard")
+      expect(text).to include("Suggested fallback list:")
       expect(text).to include("DSL:")
     end
   end

--- a/spec/ruby_llm/contract/eval/retry_optimizer_spec.rb
+++ b/spec/ruby_llm/contract/eval/retry_optimizer_spec.rb
@@ -283,7 +283,7 @@ RSpec.describe RubyLLM::Contract::Eval::RetryOptimizer do
       result.print_summary(output)
       text = output.string
 
-      expect(text).to include("retry chain optimization")
+      expect(text).to include("fallback list optimization")
       expect(text).to include("Hardest eval: hard")
       expect(text).to include("Suggested fallback list:")
       expect(text).to include("DSL:")


### PR DESCRIPTION
Consolidates four guide optimizations into one batch. The work is thematically coupled — terminology alignment across the code-to-guide boundary, a DSL bug fix that blocks copy-paste, and narrative-continuity rewrites keeping every guide on the `SummarizeArticle` case from the README.

Previously split across three PRs (#18, #19, #20), now consolidated here. A fourth guide (`eval_first.md`) joined the batch in this branch.

## What's in this PR

### 1. Version bump to 0.7.2

### 2. Terminal output labels renamed (non-breaking)

`print_summary` output strings aligned with the README narrative. Programmatic metric names stable.

| Before | After |
|---|---|
| `Constraining eval:` | `Hardest eval:` |
| `Suggested chain:` | `Suggested fallback list:` |
| column `single-shot` | `first-attempt` |
| column `escalation` | `fallback %` |

`RetryOptimizer::Result` now exposes `hardest_eval` as an alias for `constraining_eval`. Programmatic metric names (`single_shot_cost`, `single_shot_latency_ms`, `escalation_rate`) unchanged.

Copilot finding on `model_comparison.rb` (column widths didn't match after header rename) addressed: header and data row both use `%-13s` for the `first-attempt` column, separator bumped from `chain_width + 60` → `chain_width + 62`.

### 3. `docs/guide/optimizing_retry_policy.md` rewritten

**17.7k → 6.4k chars**. Continues the `SummarizeArticle` narrative from README. Offline mode clearly positioned as a wiring check; real optimization via `LIVE=1 RUNS=3`. Output samples captured from actual `print_summary` runs.

Two codex review rounds (mid/senior Ruby persona): `BIGGER REWORK` → `ONE OR TWO TWEAKS` → applied.

### 4. `docs/guide/getting_started.md` rewritten

**8.7k → 6.1k chars**. Every example uses `SummarizeArticle` with the same schema and validates as the README. Walkthrough layers on `max_input` / `max_output` / `max_cost` / `define_eval` / `run_eval` / `save_baseline!` / `pass_eval`.

Section order reshuffled: Evals and CI gates before Budget caps (README links to this guide as "CI regression gates").

Removed: Structured Prompts + Dynamic Prompts (delegated to `prompt_ast.md`), "Already using ruby_llm?" (README covers), "Reasoning effort" (niche), "Model priority" paragraph (redundant).

Copilot finding on `trace[:cost]` addressed: `# => 0.000042` → `# => 0.00052 (sum of all attempts)` — matches `RetryExecutor` sum semantics.

API verified via `tmp/verify_getting_started.rb` against the real adapter.

### 5. `docs/guide/eval_first.md` refined

**6.3k → 5.0k chars**. Switched every example from `ClassifyTicket` to `SummarizeArticle`. Team workflow section trimmed to 5 one-line bullets linking back to `getting_started.md` for the matcher chain — the old version duplicated setup steps that now live there.

Kept intact: Core Rule, Three eval kinds (smoke/regression/ab), `sample_response` caveat, few-shot note, model-selection-after-prompt-stability ordering, Short Version. These are the philosophy bits that belong specifically in eval-first.

API calls verified against the code: `compare_with` and `compared_with` matcher chain both real.

### 6. `docs/guide/testing.md` refined

**10.7k → 7.4k chars**. Switched every example from `ClassifyIntent` / `ClassifyTicket` / `EvaluatePersona` / `EvaluateComparative` to `SummarizeArticle`.

Kept intact (unique to testing guide): Test Adapter, symbol-keys caveat, `stub_step` / `stub_steps` / `stub_all_steps` reference with block form, RSpec setup + Minitest equivalent, `satisfy_contract` + `pass_eval` matchers, Offline vs Online decision table, Inspecting failures (Report API), Soft observations, Baseline file format.

Cut or compressed with links back to proper homes: Threshold Gating (getting_started has the matcher chain), Rake Task (getting_started), Baseline Regression walkthrough (getting_started + eval_first), Prompt A/B walkthrough (eval_first).

### 7. P3 sanity pass (`best_practices.md`, `pipeline.md`, `migration.md`)

Terminology and case consistency over the three remaining guides.

- **`best_practices.md`**: section 6 renamed "Model escalation" → "Model fallback" (matches README + Optimizing retry_policy). Fabricated `90% / 9% / 1%` attempt distribution removed. `AnalyzeCompetitor` / diverse validate cases kept — this is a patterns reference, a SummarizeArticle monoculture would fight the topic.
- **`pipeline.md`**: eval example fixed (`TicketPipeline` replaced with `MeetingFollowUp`, which is actually defined earlier). `See also` section added. `MeetingFollowUp` case kept — pipelines need multi-step, SummarizeArticle is single-step.
- **`migration.md`**: `ClassifyTicket` replaced with `SummarizeArticle` across every example. The original ticket-classification case carried the same "fabricated case study" baggage README feedback called out. Before/After diff now shows a real article-summary service wrapped in a contract. `See also` section added.

### 8. `docs/guide/output_schema.md` DSL bug fix (critical)

The "Supported constraints" table documented keywords in **camelCase** (`minLength`, `maxLength`, `minItems`, `maxItems`, `additionalProperties`). Those are JSON Schema spec names, not the actual `ruby_llm-schema` DSL. The DSL accepts snake_case (`min_length`, `min_items`, …) and converts internally.

Every copy-paste from the previous table would have raised `ArgumentError`. Fixed across the table, added a short note on the internal conversion.

Verified: `tmp/verify_schema_dsl.rb` builds a schema using every snake_case constraint and round-trips to the expected camelCase in the JSON Schema output.

Companion audit of `prompt_ast.md` — no changes needed.

## CHANGELOG entry

`0.7.2` — terminal label renames (non-breaking) + guide rewrites. Programmatic API unchanged.

## Tests

`bundle exec rspec` — 1341 examples, 0 failures, 8 pending.

## Size impact

| File | Before | After | Δ |
|---|---|---|---|
| `optimizing_retry_policy.md` | 17.7k | 6.4k | −64% |
| `getting_started.md` | 8.7k | 6.1k | −30% |
| `eval_first.md` | 6.3k | 5.0k | −20% |
| `testing.md` | 10.7k | 7.4k | −31% |
| `output_schema.md` | 3.3k | 3.4k | +3% (note added) |
| `best_practices.md` | 3.5k | 3.5k | ±0% (terminology) |
| `pipeline.md` | 4.2k | 4.3k | +2% (See also link) |
| `migration.md` | 4.6k | 5.4k | +17% (See also + clearer case) |
| **Total guide content** | **54.3k** | **36.7k** | **−32%** |

## Closed PRs

- #18 (`docs/optimizing-retry-policy-rewrite`) — content here.
- #19 (`docs/getting-started-rewrite`) — content here.
- #20 (`docs/output-schema-prompt-ast-fixes`) — content here.
