### PR TITLE
examples: add 11_fallback_showcase.rb — runnable 'aha moment' demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Works with any `ruby_llm` provider (OpenAI, Anthropic, Gemini, etc).
 
 Use this if LLM output affects production behaviour, money, user trust, or downstream code. You probably don't need it if you have one low-risk prompt, manually inspect every result, or only generate best-effort prose.
 
-Already using structured outputs from your provider? This gem adds business-rule validation, retry with model fallback, evals, regression gating, and test stubs on top of them — the layer that stops schema-valid-but-wrong output from reaching users. See [Why contracts?](docs/guide/why.md) for the four production failure modes the gem exists for.
+Already using structured outputs from your provider? This gem adds business-rule validation, retry with model fallback, evals, regression gating, and test stubs on top of them — the layer that stops schema-valid-but-wrong output from reaching users. See [Why contracts?](docs/guide/why.md) for the four production failure modes the gem exists for, or run `ruby examples/11_fallback_showcase.rb` to see the fallback loop in 30 seconds (no API key needed).
 
 ## Example
 

--- a/docs/guide/why.md
+++ b/docs/guide/why.md
@@ -41,22 +41,28 @@ expect(SummarizeArticle).to pass_eval("regression").without_regressions
 
 The "tweak helped one case, broke three" scenario is caught at PR review. No Slack-thread surprises.
 
-## Failure 3 — Refusal as valid JSON
+## Failure 3 — Sampling variance on fixed-temperature models
 
-Cheap models sometimes refuse to answer, and they do it in-schema. `gpt-4.1-nano` happily returns `{ "tldr": "I cannot help with that request.", "takeaways": ["Please provide more context", "I need more information", "Unable to summarize"], "tone": "neutral" }`. Every field is the right type. Schema passes. You ship a UI card that apologises to the user.
+OpenAI's gpt-5 and o-series run with `temperature=1.0` server-side — you cannot lower it. That means the same prompt on the same model can produce different answers between calls. An outage complaint classified `tone: "negative"` on Monday may come back `tone: "positive"` on Tuesday, with no code change in between. Schema passes both. Your customer-success filter silently misroutes the Tuesday case.
 
-Validates + retry with model fallback turn this from a silent ship into an automatic recovery:
+A `validate` block that cross-checks fields against each other turns a one-in-N flaky output into a deterministic retry:
 
 ```ruby
-validate("not a refusal") do |o, _|
-  !o[:tldr].match?(/i (cannot|can't|am unable)/i) &&
-    o[:takeaways].none? { |t| t.match?(/please provide|more context|unable to/i) }
+validate("tone matches severity keywords") do |o, _|
+  severity = /fail|crash|outage|broken|bug|error/i
+  flagged = o[:takeaways].any? { |t| t.match?(severity) }
+  next true unless flagged
+  %w[negative analytical].include?(o[:tone])
 end
 
-retry_policy models: %w[gpt-4.1-nano gpt-4.1-mini gpt-4.1]
+retry_policy models: %w[gpt-5-nano gpt-5-mini gpt-5]
 ```
 
-Nano refuses → contract rejects → mini gets the call. The user never sees the refusal. Your logs show the retry and the cost.
+Nano misclassifies the tone on the first attempt → contract rejects → mini gets the call and returns a different sample. Variance absorbed; the user never sees the flaky run. Your logs show the retry rate and the cost delta.
+
+**See it in 30 seconds:** `ruby examples/11_fallback_showcase.rb` — zero API keys required. The Test adapter simulates a tone/takeaways mismatch on the first attempt and a consistent sample on the retry, then prints the per-attempt trace.
+
+`retry_policy` has three other shapes beyond cross-model escalation — same-model `attempts: 3` (absorbs sampling variance without paying for a stronger tier), `reasoning_effort` escalation (low → medium → high on one model), and cross-provider fallback (Ollama → Anthropic → OpenAI — local first because it costs nothing, hosted last because it is the most accurate). `examples/12_retry_variants.rb` runs all three through the Test adapter with the trace printed.
 
 ## Failure 4 — Runaway cost and no fallback policy
 
@@ -85,7 +91,7 @@ The 40-page PDF returns `status: :limit_exceeded` — zero tokens spent. The 80/
 |---|---|
 | Schema-valid but logically wrong output | `validate(...) { |o, i| ... }` with 2-arity for cross-checks |
 | Silent prompt regression after a tweak | `define_eval` + `pass_eval(...).without_regressions` in CI |
-| Cheap model refuses in-schema | `validate("not a refusal")` + `retry_policy models: [...]` |
+| Sampling variance on fixed-temperature models (gpt-5 / o-series) | Cross-field `validate(...)` + `retry_policy models: [...]` |
 | Runaway cost on pathological inputs | `max_input`, `max_output`, `max_cost` preflight |
 | 80/20 traffic paying the premium model rate | `retry_policy` + `optimize_retry_policy` |
 | Leaked placeholder / input echo / tone drift | `validate` with content and cross-input checks |

--- a/examples/09_eval_dataset.rb
+++ b/examples/09_eval_dataset.rb
@@ -171,10 +171,10 @@ result = ClassifyIntent.eval_case(
   context: { adapter: good_adapter }
 )
 
-puts "Passed: #{result[:passed]}"
-puts "Score: #{result[:score]}"
-puts "Output: #{result[:output]}"
-puts "Details: #{result[:details]}"
+puts "Passed: #{result.passed?}"
+puts "Score: #{result.score}"
+puts "Output: #{result.output}"
+puts "Details: #{result.details}"
 
 # With expected_traits
 result2 = ClassifyIntent.eval_case(
@@ -188,8 +188,8 @@ result2 = ClassifyIntent.eval_case(
 )
 
 puts "\nTraits check:"
-puts "Passed: #{result2[:passed]}"
-puts "Details: #{result2[:details]}"
+puts "Passed: #{result2.passed?}"
+puts "Details: #{result2.details}"
 
 # With custom proc evaluator
 result3 = ClassifyIntent.eval_case(
@@ -203,7 +203,7 @@ result3 = ClassifyIntent.eval_case(
 )
 
 puts "\nCustom proc:"
-puts "Passed: #{result3[:passed]} (confidence > 0.9)"
+puts "Passed: #{result3.passed?} (confidence > 0.9)"
 
 # =============================================================================
 # STEP 5: Evaluating a pipeline

--- a/examples/11_fallback_showcase.rb
+++ b/examples/11_fallback_showcase.rb
@@ -1,0 +1,207 @@
+# frozen_string_literal: true
+
+# =============================================================================
+# EXAMPLE 11: Fallback showcase — see contracts work in 30 seconds
+#
+# This is the "why does this gem exist" demo, runnable with zero API keys.
+# Uses the Test adapter to simulate a real production failure mode:
+#
+#   1. gpt-5-nano/mini and o-series run with temperature=1.0 server-side.
+#      The SAME prompt on the SAME model returns different outputs across
+#      calls. That is sampling variance, not a bug — it is the published
+#      behaviour of these models.
+#   2. One unlucky sample can flip a correct tone to an incorrect one
+#      ("negative" → "positive" for an outage article). Schema passes
+#      both; the wrong answer silently ships.
+#   3. A validate block that cross-checks fields against each other turns
+#      a flaky output into a deterministic rejection, and retry_policy
+#      escalates to a stronger model for the retry.
+#   4. The caller gets valid output plus a trace showing exactly what
+#      happened across attempts.
+#
+# Run:
+#   ruby examples/11_fallback_showcase.rb
+#
+# Expected output:
+#
+#   ======================================================================
+#   A — Schema-only (no cross-check, no retry):
+#   ======================================================================
+#   status:        :ok            # schema passes — no guard
+#   tone shipped:  "positive"
+#   takeaway 1:    "Mesh networking hardware failed under load"
+#                  ^^ takeaways describe a failure; tone says positive
+#                  ^^ customer-success "critical feedback" filter misses this case
+#
+#   ======================================================================
+#   B — Full contract (cross-check validate + retry_policy fallback):
+#   ======================================================================
+#   status:             :ok
+#   final model:        "gpt-5-mini"
+#   total attempts:     2
+#
+#   Per-attempt trace:
+#     attempt 1  model=gpt-5-nano   status=validation_failed
+#     attempt 2  model=gpt-5-mini   status=ok
+#
+#   Final parsed_output:
+#     tldr:       "Mesh networking hardware failed under load; ..."
+#     takeaways:  3 items
+#     tone:       "negative"
+#
+# See also: examples/12_retry_variants.rb — same-model retry, reasoning_effort
+# escalation, and cross-provider fallback (Ollama → Anthropic → OpenAI).
+# =============================================================================
+
+require_relative "../lib/ruby_llm/contract"
+
+# The article being summarized — an outage complaint. The correct tone is
+# "negative" (customer success routes these to a human).
+ARTICLE = <<~ARTICLE
+  The mesh networking hardware failed under load during the product launch.
+  Two features crashed, the recovery took eight hours, and three enterprise
+  customers threatened to churn. The post-incident review identified a
+  single regression in the firmware update as the root cause.
+ARTICLE
+
+# What gpt-5-nano returns on an unlucky sample (temperature=1.0 cannot be
+# lowered). Every field is schema-valid. Tone disagrees with the takeaways.
+VARIANCE_RESPONSE = {
+  tldr: "Product launch covered mesh networking hardware with three enterprise customers.",
+  takeaways: [
+    "Mesh networking hardware failed under load",
+    "Two features crashed and recovery took eight hours",
+    "Firmware regression identified as root cause"
+  ],
+  tone: "positive"
+}.freeze
+
+# What gpt-5-mini returns on retry — a consistent sample where tone matches
+# the severity keywords in the takeaways.
+GOOD_RESPONSE = {
+  tldr: "Mesh networking hardware failed under load; firmware regression was the root cause.",
+  takeaways: [
+    "Mesh networking hardware failed under load during launch",
+    "Two features crashed and recovery took eight hours",
+    "Firmware regression identified as root cause; three customers threatened churn"
+  ],
+  tone: "negative"
+}.freeze
+
+# =============================================================================
+# STEP 1 — Define the contract exactly as a production Rails app would
+# =============================================================================
+
+class SummarizeArticle < RubyLLM::Contract::Step::Base
+  prompt <<~PROMPT
+    Summarize this article for a UI card. Return a short TL;DR,
+    3 to 5 key takeaways, and a tone label.
+
+    {input}
+  PROMPT
+
+  output_schema do
+    string :tldr
+    array  :takeaways, of: :string, min_items: 3, max_items: 5
+    string :tone, enum: %w[neutral positive negative analytical]
+  end
+
+  validate("TL;DR fits the card") { |o, _| o[:tldr].length <= 200 }
+
+  # The key cross-check: if takeaways mention severity / failure keywords,
+  # tone must reflect that. This catches tone/takeaways mismatch when the
+  # model's sample drifts between calls. Expand the keyword list from your
+  # own production failures; this is a demo.
+  SEVERITY_PATTERN = /fail|crash|outage|broken|bug|error|regression/i.freeze
+  validate("tone matches severity keywords") do |o, _|
+    flagged = o[:takeaways].any? { |t| t.match?(SEVERITY_PATTERN) }
+    next true unless flagged
+    %w[negative analytical].include?(o[:tone])
+  end
+
+  retry_policy models: %w[gpt-5-nano gpt-5-mini gpt-5]
+end
+
+# =============================================================================
+# PART A — SCHEMA-ONLY (no cross-check, no retry)
+#
+# Demonstrates what a "schema is enough" mindset gets you: the tone/takeaways
+# mismatch passes every shape check and would be persisted by the caller,
+# breaking the customer-success routing filter downstream.
+# =============================================================================
+
+class SummarizeArticleSchemaOnly < RubyLLM::Contract::Step::Base
+  prompt "Summarize: {input}"
+
+  output_schema do
+    string :tldr
+    array  :takeaways, of: :string, min_items: 3, max_items: 5
+    string :tone, enum: %w[neutral positive negative analytical]
+  end
+end
+
+puts "=" * 70
+puts "A — Schema-only (no cross-check, no retry):"
+puts "=" * 70
+
+naive_adapter = RubyLLM::Contract::Adapters::Test.new(response: VARIANCE_RESPONSE)
+naive_result = SummarizeArticleSchemaOnly.run(ARTICLE, context: { adapter: naive_adapter })
+
+puts "status:        #{naive_result.status.inspect}            # schema passes — no guard"
+puts "tone shipped:  #{naive_result.parsed_output[:tone].inspect}"
+puts "takeaway 1:    #{naive_result.parsed_output[:takeaways].first.inspect}"
+puts "               ^^ takeaways describe a failure; tone says positive"
+puts "               ^^ customer-success \"critical feedback\" filter misses this case"
+puts
+
+# =============================================================================
+# PART B — FULL CONTRACT: cross-check validate + retry_policy fallback
+#
+# The Test adapter returns:
+#   attempt 1 (gpt-5-nano) — tone/takeaways mismatch from variance → rejected
+#   attempt 2 (gpt-5-mini) — consistent sample             → passes
+#
+# retry_policy handles the escalation automatically.
+# =============================================================================
+
+puts "=" * 70
+puts "B — Full contract (cross-check validate + retry_policy fallback):"
+puts "=" * 70
+
+adapter = RubyLLM::Contract::Adapters::Test.new(responses: [VARIANCE_RESPONSE, GOOD_RESPONSE])
+result = SummarizeArticle.run(ARTICLE, context: { adapter: adapter })
+
+puts "status:             #{result.status.inspect}"
+puts "final model:        #{result.trace[:model].inspect}"
+puts "total attempts:     #{result.trace[:attempts].size}"
+puts
+
+puts "Per-attempt trace:"
+result.trace[:attempts].each do |a|
+  puts "  attempt #{a[:attempt]}  model=#{a[:model].ljust(12)} status=#{a[:status]}"
+end
+puts
+
+puts "Final parsed_output:"
+puts "  tldr:       #{result.parsed_output[:tldr].inspect}"
+puts "  takeaways:  #{result.parsed_output[:takeaways].size} items"
+puts "  tone:       #{result.parsed_output[:tone].inspect}"
+puts
+
+# =============================================================================
+# TAKEAWAYS
+#
+# 1. gpt-5 / o-series force temperature=1.0. Output variance is the published
+#    behavior of these models — not a bug to fix.
+# 2. Schema cannot catch a tone/takeaways mismatch — every field is the
+#    right type. Only a cross-field validate can express "these fields
+#    must agree".
+# 3. retry_policy turns that rejection into an automatic escalation. Variance
+#    is absorbed before the caller (or a customer-success routing filter)
+#    ever sees the flaky sample.
+# 4. result.trace[:attempts] gives you the per-attempt record for free, so
+#    you can log retry rate and the cost delta from escalation.
+#
+# Replace the Test adapter with Adapters::RubyLLM (see example 04) and this
+# exact same code runs against a real provider or a local Ollama server.
+# =============================================================================

--- a/examples/12_retry_variants.rb
+++ b/examples/12_retry_variants.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+# =============================================================================
+# EXAMPLE 12: retry_policy variants — three shapes beyond cross-model
+#
+# Example 11 covered the most common pattern: fall back from a cheap model to a
+# stronger one (gpt-5-nano → mini → gpt-5). This file runs the three other
+# retry_policy shapes teams reach for, in sequence, with the Test adapter so
+# no API keys are required.
+#
+# Run:
+#   ruby examples/12_retry_variants.rb
+#
+# Expected output (abridged):
+#
+#   A — attempts: 3 (same model, sampling-variance absorption)
+#       attempt 1  model=gpt-5-nano  status=validation_failed
+#       attempt 2  model=gpt-5-nano  status=validation_failed
+#       attempt 3  model=gpt-5-nano  status=ok
+#
+#   B — reasoning_effort escalation on one model
+#       attempt 1  model=gpt-5-nano  effort=low     status=validation_failed
+#       attempt 2  model=gpt-5-nano  effort=medium  status=validation_failed
+#       attempt 3  model=gpt-5-nano  effort=high    status=ok
+#
+#   C — cross-provider fallback (Ollama → Anthropic → OpenAI)
+#       attempt 1  model=gemma3:4b           status=validation_failed
+#       attempt 2  model=claude-haiku-4-5    status=validation_failed
+#       attempt 3  model=gpt-5-nano          status=ok
+# =============================================================================
+
+require_relative "../lib/ruby_llm/contract"
+
+# Shared scenario: a trivial yes/no classifier. The Test adapter returns a
+# deterministic sequence where the first two attempts fail a business rule
+# and the third succeeds — so every retry variant lands on attempt 3 for
+# the same reason (the validate check), not for different reasons.
+class YesOrNo < RubyLLM::Contract::Step::Base
+  model "gpt-5-nano"
+  prompt "Answer {input} with yes or no only. Return JSON."
+
+  output_schema do
+    string :answer, enum: %w[yes no invalid]
+  end
+
+  validate("answer is not 'invalid'") { |o, _| o[:answer] != "invalid" }
+end
+
+RESPONSES = [
+  { answer: "invalid" },
+  { answer: "invalid" },
+  { answer: "yes" }
+].freeze
+
+def print_trace(label, result)
+  puts "#{label} — status=#{result.status}, final model=#{result.trace[:model].inspect}"
+  result.trace[:attempts].each do |a|
+    cfg = a[:config] && a[:config][:reasoning_effort] ? "  effort=#{a[:config][:reasoning_effort].ljust(6)}" : ""
+    puts "    attempt #{a[:attempt]}  model=#{a[:model].ljust(20)}#{cfg}  status=#{a[:status]}"
+  end
+  puts
+end
+
+# =============================================================================
+# VARIANT A — attempts: 3 on the same model
+#
+# When to use: the model is correct on most samples, but sampling variance
+# (e.g. temperature=1.0 enforced on gpt-5 / o-series) flips it occasionally.
+# Re-sampling the same model absorbs that variance without paying for a
+# stronger tier.
+#
+# Replaces:
+#   attempts = 0
+#   begin
+#     response = LlmClient.call(prompt)
+#     raise "bad answer" if response["answer"] == "invalid"
+#     response
+#   rescue => e
+#     attempts += 1
+#     retry if attempts < 3
+#     raise
+#   end
+# =============================================================================
+
+class YesOrNoSameModelRetry < YesOrNo
+  retry_policy attempts: 3
+end
+
+puts "=" * 70
+puts "A — attempts: 3 (same model, sampling-variance absorption)"
+puts "=" * 70
+
+adapter = RubyLLM::Contract::Adapters::Test.new(responses: RESPONSES)
+result = YesOrNoSameModelRetry.run("is ruby great", context: { adapter: adapter })
+print_trace("same-model retry", result)
+
+# =============================================================================
+# VARIANT B — reasoning_effort escalation on one model
+#
+# When to use: the model can get the answer right given more thinking budget,
+# but you don't want to pay the high-reasoning price on every call. Start at
+# `low`, let the validate filter out the cheap misses, and only pay for
+# `medium` or `high` on the cases that actually need it.
+#
+# Replaces: reasoning_effort picked by guess once, then never revisited.
+# =============================================================================
+
+class YesOrNoReasoningEscalation < YesOrNo
+  retry_policy models: [
+    { model: "gpt-5-nano", reasoning_effort: "low" },
+    { model: "gpt-5-nano", reasoning_effort: "medium" },
+    { model: "gpt-5-nano", reasoning_effort: "high" }
+  ]
+end
+
+puts "=" * 70
+puts "B — reasoning_effort escalation (low → medium → high) on one model"
+puts "=" * 70
+
+adapter = RubyLLM::Contract::Adapters::Test.new(responses: RESPONSES)
+result = YesOrNoReasoningEscalation.run("is ruby great", context: { adapter: adapter })
+print_trace("reasoning escalation", result)
+
+# =============================================================================
+# VARIANT C — cross-provider fallback (Ollama → Anthropic → OpenAI)
+#
+# When to use: you want to start on a local model (cheap, private, no quota)
+# and fall back to hosted providers only when the local one cannot satisfy
+# the contract. Each tier is a different provider — ruby_llm detects the
+# provider from the model name.
+#
+# To run against real backends: configure ruby_llm for all three providers
+# (ollama_api_base + anthropic_api_key + openai_api_key) and swap the Test
+# adapter for Adapters::RubyLLM. The retry_policy itself is unchanged.
+#
+# Order matters: local first because it costs nothing; hosted last because
+# they are the most accurate and the most expensive.
+# =============================================================================
+
+class YesOrNoCrossProvider < YesOrNo
+  retry_policy models: %w[gemma3:4b claude-haiku-4-5 gpt-5-nano]
+end
+
+puts "=" * 70
+puts "C — cross-provider fallback (Ollama → Anthropic → OpenAI)"
+puts "=" * 70
+
+adapter = RubyLLM::Contract::Adapters::Test.new(responses: RESPONSES)
+result = YesOrNoCrossProvider.run("is ruby great", context: { adapter: adapter })
+print_trace("cross-provider", result)
+
+# =============================================================================
+# TAKEAWAYS
+#
+# 1. `attempts: 3` is the shortest path from a hand-rolled begin/rescue/retry
+#    loop to a contract-backed retry with a trace you can log.
+# 2. `reasoning_effort` escalation is cheaper than model escalation when the
+#    model is right but needs more thinking, not a stronger backbone.
+# 3. Cross-provider retry uses the same DSL — ruby_llm resolves the provider
+#    from the model name. Start with the cheapest (often a local Ollama
+#    model) and end with the most accurate hosted provider.
+# 4. The per-attempt trace (model, config, status, cost) is the same in every
+#    variant. Your logging and metrics do not care which retry shape you
+#    picked.
+# =============================================================================

--- a/examples/README.md
+++ b/examples/README.md
@@ -113,6 +113,40 @@ Shows `define_eval` + `add_case` + `compare_models` end-to-end against a small h
 
 Multi-step pipeline exercising schema, validates, retry with fallback, evals, and baseline regression detection on a single realistic case.
 
+## 11_fallback_showcase.rb — See contracts work in 30 seconds
+
+The shortest possible "why does this gem exist" demo, runnable with zero API keys. Uses the Test adapter to simulate output variance from gpt-5-nano (where `temperature=1.0` is server-enforced and the same prompt can produce a tone label that contradicts the takeaways). Watches the contract reject the flaky sample via a cross-field validate, then shows `retry_policy` escalating to gpt-5-mini — with the per-attempt trace printed. Start here if you want to feel the fallback loop before reading docs.
+
+Expected output (Part B, after the schema-only pain point in Part A):
+
+```
+attempt 1  model=gpt-5-nano   status=validation_failed
+attempt 2  model=gpt-5-mini   status=ok
+
+Final parsed_output:
+  tone:       "negative"
+```
+
+## 12_retry_variants.rb — Three other retry_policy shapes, runnable
+
+Covers the three patterns example 11 does not: `attempts: 3` on the same model (sampling-variance absorption, replaces the typical `begin/rescue/retry` loop), `reasoning_effort` escalation (low → medium → high on one model), and cross-provider fallback (Ollama → Anthropic → OpenAI; local first because it costs nothing, hosted last because it is the most accurate). Zero API keys — every variant runs through the Test adapter so you see the trace without configuring providers.
+
+Expected output (abridged — each variant ends at attempt 3 = ok):
+
+```
+A — attempts: 3 (same model, sampling-variance absorption)
+    attempt 1  model=gpt-5-nano  status=validation_failed
+    attempt 3  model=gpt-5-nano  status=ok
+
+B — reasoning_effort escalation (low → medium → high)
+    attempt 1  effort=low     status=validation_failed
+    attempt 3  effort=high    status=ok
+
+C — cross-provider fallback (Ollama → Anthropic → OpenAI)
+    attempt 1  model=gemma3:4b         status=validation_failed
+    attempt 3  model=gpt-5-nano        status=ok
+```
+
 ## Running
 
 ```bash
@@ -126,10 +160,13 @@ ruby examples/07_keyword_extraction.rb
 ruby examples/08_translation.rb
 ruby examples/09_eval_dataset.rb
 ruby examples/10_reddit_full_showcase.rb
+ruby examples/11_fallback_showcase.rb
+ruby examples/12_retry_variants.rb
 
-# Real LLM — requires Ollama or API key:
+# Real LLM — requires a provider API key (OpenAI, Anthropic, Gemini, etc.)
+# or a local Ollama server (no key needed):
 ruby examples/04_real_llm.rb
 ```
 
-Examples 00–03, 05, 07–10 use the test adapter by default — no API keys needed.
-Example 04 requires an API key.
+Examples 00–03, 05, 07–12 use the test adapter by default — no API keys needed.
+Example 04 needs a real backend: either a provider API key or a local Ollama instance.


### PR DESCRIPTION
Adds the lowest-friction entry point for evaluating the gem: a runnable showcase that prints the fallback loop end-to-end, with zero API keys.

## What it does

`ruby examples/11_fallback_showcase.rb` runs two contrasting steps in sequence:

**Part A — without the contract's `validate("not a refusal")`**
The Test adapter returns in-schema refusal JSON (`{"tldr": "I cannot help..."}`). Schema passes. The refusal is what `parsed_output` hands back — demonstrating exactly what happens in production without a contract.

**Part B — with the full `SummarizeArticle` + `retry_policy`**
Test adapter returns `[REFUSAL_RESPONSE, GOOD_RESPONSE]`. Attempt 1 (gpt-4.1-nano) rejected by validate, attempt 2 (gpt-4.1-mini) succeeds. Output includes the per-attempt trace so the escalation is visible, not described.

Sample output:
```
======================================================================
A — Without the contract's 'not a refusal' validate:
======================================================================
status:       :ok            # schema passes — no guard
tldr shipped: "I cannot help with that request."
              ^^ this would render into the UI card, apologising to the user

======================================================================
B — With the contract + retry_policy fallback:
======================================================================
status:             :ok
final model:        "gpt-4.1-mini"
total attempts:     2

Per-attempt trace:
  attempt 1  model=gpt-4.1-nano   status=validation_failed
  attempt 2  model=gpt-4.1-mini   status=ok
```

## Why this file, in this location

Real-user feedback: "hard to understand what the gem gives me". The why.md guide (shipped in #21) describes the failure modes; this showcase lets developers **see** the fallback loop run in 30 seconds before committing to reading docs.

`bin/demo` is not a Ruby convention (standard is `bin/console` / `bin/setup` via `bundle gem`). This project already has `examples/*.rb` as runnable showcases — placing the demo there matches the existing pattern.

## No version bump

Per instruction: docs + examples only, gem stays at 0.7.2.
