### PR TITLE
examples + spec: pipeline run_eval coverage (closes 09 STEP 5 known issue)

### DIFF
--- a/examples/04_summarize_and_translate.rb
+++ b/examples/04_summarize_and_translate.rb
@@ -146,6 +146,41 @@ puts "Total cost:        $#{result.trace.total_cost || '0.0 (Test adapter)'}"  #
 #   Total cost:        $0.0 (Test adapter)
 
 # =============================================================================
+# Evaluating the whole pipeline
+#
+# A pipeline can run against a dataset the same way a single step does.
+# The `expected:` hash matches the FINAL step's output — here the review
+# verdict — so a regression anywhere along the chain shows up in one place.
+# =============================================================================
+
+TranslatedSummaryPipeline.define_eval("smoke") do
+  add_case "release post",
+           input: "Ruby 3.4 ships with frozen string literals, YJIT speedups, parser fixes.",
+           expected: { overall_verdict: "pass" }
+end
+
+# One Test adapter response per step in order (summarise → translate → review):
+eval_adapter = RubyLLM::Contract::Adapters::Test.new(responses: [
+  { tldr: "Ruby 3.4 ships frozen string literals, YJIT speedups, parser fixes.",
+    takeaways: %w[frozen-strings yjit parser-fixes], tone: "analytical" },
+  { tldr: "Ruby 3.4 arrive avec les littéraux de chaînes figés, des gains YJIT, ...",
+    takeaways: %w[lit-figes yjit-fr parser-fr], tone: "analytical" },
+  { overall_verdict: "pass",
+    reviews: [{ takeaway_index: 0, verdict: "pass", issue: "" }] }
+])
+
+report = TranslatedSummaryPipeline.run_eval("smoke", context: { adapter: eval_adapter })
+puts "\nEval score:      #{report.score}"           # => 1.0
+puts "Eval pass rate:  #{report.pass_rate}"         # => 1/1
+puts "Eval passed?:    #{report.passed?}"           # => true
+
+# Example console output (with Test adapter):
+#
+#   Eval score:      1.0
+#   Eval pass rate:  1/1
+#   Eval passed?:    true
+
+# =============================================================================
 # What this showcases
 #
 # - Pipeline::Base composes steps; data threads automatically from
@@ -155,4 +190,7 @@ puts "Total cost:        $#{result.trace.total_cost || '0.0 (Test adapter)'}"  #
 # - Fail-fast: if SummarizeArticle's "TL;DR fits the card" validate
 #   rejects, the translate and review steps never run — no downstream
 #   tokens wasted.
+# - A pipeline has its own `define_eval` + `run_eval` pair; expectations
+#   match the final step's output, catching end-to-end regressions in one
+#   dataset instead of per-step duplicates.
 # =============================================================================

--- a/spec/integration/pipeline_eval_spec.rb
+++ b/spec/integration/pipeline_eval_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+# Pipeline eval contract — prevents the regression where pipeline-level
+# `run_eval` silently stopped working because of strict additional-property
+# handling. The bug that prompted this spec was in example code (extra keys
+# in a Test response), but the gem-level behaviour we rely on (define_eval
+# on a Pipeline, run_eval matching the FINAL step's output) has no integration
+# coverage outside this file.
+
+require "spec_helper"
+
+RSpec.describe "Pipeline eval end-to-end" do
+  before do
+    stub_const("SummarizeArticle", Class.new(RubyLLM::Contract::Step::Base) do
+      prompt "Summarize: {input}"
+      output_schema do
+        string :tldr, max_length: 200
+        array  :takeaways, of: :string, min_items: 3, max_items: 5
+        string :tone, enum: %w[neutral positive negative analytical]
+      end
+    end)
+
+    stub_const("TranslateSummary", Class.new(RubyLLM::Contract::Step::Base) do
+      input_type Hash
+      prompt "Translate: {tldr}"
+      output_schema do
+        string :tldr, max_length: 200
+        array  :takeaways, of: :string, min_items: 3, max_items: 5
+        string :tone, enum: %w[neutral positive negative analytical]
+      end
+    end)
+
+    stub_const("ReviewTranslation", Class.new(RubyLLM::Contract::Step::Base) do
+      input_type Hash
+      prompt "Review: {tldr}"
+      output_schema do
+        string :overall_verdict, enum: %w[pass warning fail]
+      end
+    end)
+
+    stub_const("TranslatedPipeline", Class.new(RubyLLM::Contract::Pipeline::Base) do
+      step SummarizeArticle,  as: :summarise
+      step TranslateSummary,  as: :translate
+      step ReviewTranslation, as: :review
+    end)
+
+    TranslatedPipeline.define_eval("smoke") do
+      add_case "release post",
+               input: "Ruby 3.4 ships frozen string literals.",
+               expected: { overall_verdict: "pass" }
+    end
+  end
+
+  let(:adapter) do
+    RubyLLM::Contract::Adapters::Test.new(responses: [
+      { tldr: "EN summary", takeaways: %w[a b c], tone: "analytical" },
+      { tldr: "FR summary", takeaways: %w[a b c], tone: "analytical" },
+      { overall_verdict: "pass" }
+    ])
+  end
+
+  it "runs run_eval end-to-end on a pipeline and scores against the final step's output" do
+    report = TranslatedPipeline.run_eval("smoke", context: { adapter: adapter })
+
+    expect(report.score).to eq(1.0)
+    expect(report.pass_rate).to eq("1/1")
+    expect(report.passed?).to be true
+
+    case_result = report.results.first
+    expect(case_result).to be_passed
+    expect(case_result.name).to eq("release post")
+  end
+
+  it "fails the eval when the final step's output does not match expected" do
+    failing_adapter = RubyLLM::Contract::Adapters::Test.new(responses: [
+      { tldr: "EN summary", takeaways: %w[a b c], tone: "analytical" },
+      { tldr: "FR summary", takeaways: %w[a b c], tone: "analytical" },
+      { overall_verdict: "fail" }
+    ])
+
+    report = TranslatedPipeline.run_eval("smoke", context: { adapter: failing_adapter })
+
+    expect(report.score).to eq(0.0)
+    expect(report.passed?).to be false
+    expect(report.results.first.details).to include("overall_verdict")
+  end
+
+  it "fails the eval when an intermediate step's validate rejects (fail-fast propagates to report)" do
+    stub_const("SummarizeArticleStrict", Class.new(RubyLLM::Contract::Step::Base) do
+      prompt "Summarize: {input}"
+      output_schema do
+        string :tldr, max_length: 200
+        array  :takeaways, of: :string, min_items: 3, max_items: 5
+        string :tone, enum: %w[neutral positive negative analytical]
+      end
+      validate("tldr fits card") { |o, _| o[:tldr].length <= 10 }
+    end)
+
+    stub_const("StrictPipeline", Class.new(RubyLLM::Contract::Pipeline::Base) do
+      step SummarizeArticleStrict, as: :summarise
+      step TranslateSummary,       as: :translate
+      step ReviewTranslation,      as: :review
+    end)
+
+    StrictPipeline.define_eval("fail_case") do
+      add_case "too long",
+               input: "anything",
+               expected: { overall_verdict: "pass" }
+    end
+
+    long_tldr_adapter = RubyLLM::Contract::Adapters::Test.new(responses: [
+      { tldr: "x" * 500, takeaways: %w[a b c], tone: "analytical" },
+      { overall_verdict: "pass" }
+    ])
+
+    report = StrictPipeline.run_eval("fail_case", context: { adapter: long_tldr_adapter })
+
+    expect(report.passed?).to be false
+    expect(report.results.first.details).to include("validation_failed").or include("step failed")
+  end
+end

--- a/spec/integration/pipeline_eval_spec.rb
+++ b/spec/integration/pipeline_eval_spec.rb
@@ -86,10 +86,15 @@ RSpec.describe "Pipeline eval end-to-end" do
   end
 
   it "fails the eval when an intermediate step's validate rejects (fail-fast propagates to report)" do
+    # Schema has NO max_length on tldr, so the short response passes the
+    # schema and reaches the `validate("tldr fits card")` block. That
+    # validate rejects anything over 10 chars — exercises the intended
+    # invariant-rejection path (schema max_length + validate together
+    # would short-circuit on schema before validate ever sees the output).
     stub_const("SummarizeArticleStrict", Class.new(RubyLLM::Contract::Step::Base) do
       prompt "Summarize: {input}"
       output_schema do
-        string :tldr, max_length: 200
+        string :tldr
         array  :takeaways, of: :string, min_items: 3, max_items: 5
         string :tone, enum: %w[neutral positive negative analytical]
       end
@@ -108,14 +113,20 @@ RSpec.describe "Pipeline eval end-to-end" do
                expected: { overall_verdict: "pass" }
     end
 
+    # 50-char tldr: passes schema (no max_length), fails the validate.
     long_tldr_adapter = RubyLLM::Contract::Adapters::Test.new(responses: [
-      { tldr: "x" * 500, takeaways: %w[a b c], tone: "analytical" },
+      { tldr: "x" * 50, takeaways: %w[a b c], tone: "analytical" },
       { overall_verdict: "pass" }
     ])
 
     report = StrictPipeline.run_eval("fail_case", context: { adapter: long_tldr_adapter })
 
     expect(report.passed?).to be false
-    expect(report.results.first.details).to include("validation_failed").or include("step failed")
+    case_result = report.results.first
+    # Proves the validate path was exercised (not the schema):
+    # - step_status records why the intermediate step failed.
+    # - details references the validate label we defined.
+    expect(case_result.step_status).to eq(:validation_failed)
+    expect(case_result.details).to include("tldr fits card")
   end
 end


### PR DESCRIPTION
Closes the "09 STEP 5 pipeline evaluation fails" known issue flagged in PR #24's description, and adds the coverage that prevents it from regressing.

## Root cause investigation

The failure `action: additional property not allowed, priority: additional property not allowed` reproduced before PR #25. Investigation confirmed it was **example code**, not a gem bug: the Test adapter was returning a single JSON blob with all keys (`intent`, `confidence`, `action`, `priority`) for every step in the pipeline, and the second step's strict schema legitimately rejected the extra fields.

PR #25 removed the broken example section alongside the Reddit / support examples. That closed the user-visible symptom but left **pipeline-level `run_eval`** with:

- zero runnable example (nowhere to show newcomers "a pipeline has its own `define_eval`")
- zero integration coverage (a future refactor could silently break the same flow)

## What this PR adds

**1) Runnable pipeline eval in `examples/04_summarize_and_translate.rb`**

~20 new lines at the end of the file:

```ruby
TranslatedSummaryPipeline.define_eval("smoke") do
  add_case "release post",
           input: "Ruby 3.4 ships with frozen string literals...",
           expected: { overall_verdict: "pass" }
end

eval_adapter = RubyLLM::Contract::Adapters::Test.new(responses: [
  { tldr: "...", takeaways: [...], tone: "analytical" },  # summarise
  { tldr: "...", takeaways: [...], tone: "analytical" },  # translate
  { overall_verdict: "pass", reviews: [...] }             # review
])

report = TranslatedSummaryPipeline.run_eval("smoke", context: { adapter: eval_adapter })
puts "Eval score:      #{report.score}"           # => 1.0
puts "Eval pass rate:  #{report.pass_rate}"       # => 1/1
```

Expected output shown inline so readers see the result without running.

**2) Integration spec `spec/integration/pipeline_eval_spec.rb`** (3 cases)

- Happy path: end-to-end `run_eval` scores the final-step output 1.0.
- Final-step mismatch: eval scores 0.0 and surfaces the diff.
- Fail-fast propagation: a `validate` rejection in an intermediate step propagates to the report without silently passing.

These are the three invariants that would regress if a future `Pipeline::Runner` refactor re-introduced the original symptom.

## Verification

- 1287 specs pass (was 1284 + 3 new).
- 6/6 examples with Test adapter run clean (02 still requires API key as expected).

## No version bump in this PR

The follow-up bumps to 0.7.3 with a CHANGELOG entry that references this PR.
