### PR TITLE
0.7.3: adoption-friction release (docs + examples consolidation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.7.3 (2026-04-24)
 
-Adoption-friction release. No gem-level code changes — every delta is in `docs/`, `examples/`, or `spec/integration/`. Upgrading from 0.7.2 picks up the expanded guide set, the new runnable showcases, and one extra integration spec.
+Adoption-friction release. No runtime behavior changes — every delta is in `docs/`, `examples/`, or `spec/integration/` (plus the `version.rb` / Gemfile.lock bumps). Upgrading from 0.7.2 picks up the expanded guide set, the new runnable showcases, and one extra integration spec.
 
 ### Documentation
 
@@ -34,7 +34,7 @@ Every file carries an "Expected output" block in its header so readers see the r
 ### Examples — bug fixes carried along
 
 - **Schema pitfall fixed in 5 files** — `array :x do; string :y; ...; end` silently produces `items: string` and drops every declaration after the first, matching the documented pitfall in `spec/ruby_llm/contract/nested_schema_spec.rb:71`. Every affected array block is now wrapped in `object do...end`.
-- **`examples/09_eval_dataset.rb` `result[:passed]` → `result.passed?`** — the previous code called `[]` on an `Eval::CaseResult` and raised `NoMethodError` at runtime.
+- **`examples/05_eval_dataset.rb` (pre-renumber: `09_eval_dataset.rb`) `result[:passed]` → `result.passed?`** — the previous code called `[]` on an `Eval::CaseResult` and raised `NoMethodError` at runtime.
 
 ### Testing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## 0.7.3 (2026-04-24)
+
+Adoption-friction release. No gem-level code changes — every delta is in `docs/`, `examples/`, or `spec/integration/`. Upgrading from 0.7.2 picks up the expanded guide set, the new runnable showcases, and one extra integration spec.
+
+### Documentation
+
+- **New guide: `docs/guide/why.md`** — four production failure modes the gem exists for (schema-valid logically wrong, silent prompt regression, sampling variance on fixed-temperature models, runaway cost). Opens from a concrete incident each time; designed for readers who have not yet felt the pain the gem relieves.
+- **New guide: `docs/guide/rails_integration.md`** — seven Rails-specific FAQs with runnable snippets: where step classes live (`app/contracts/`), initializer setup, background jobs, `around_call` observability, RSpec/Minitest stubs, error handling in controllers, CI gate wiring.
+- **README adoption-friction pass** — added a short "Do I need this?" block after Install, a reading-order hint (`README → why.md → getting_started.md`), and outcome-based labels in the docs index ("Prevent silent prompt regressions" instead of "Eval-First", etc.).
+- **TL;DR box at the top of every guide** — single-sentence orientation for readers who land via search; "Skip if" clause added where real confusion exists (`eval_first.md`, `testing.md`, `migration.md`).
+- **API coverage gaps closed** — `estimate_cost` / `estimate_eval_cost`, `max_cost on_unknown_pricing: :warn`, `run_eval(..., concurrency:)`, `around_call` testing patterns now documented in `getting_started.md`, `eval_first.md`, `testing.md`.
+- **Industry-standard terminology** — `temperature-locked` → `fixed-temperature`, `variance-induced` → `sampling variance`, `severity signals` → `severity keywords`, `takeaway drift` → `tone/takeaways mismatch`.
+- **`docs/architecture.md` refresh** — diagram now reflects the current class layout: added `Step::RetryPolicy`, `Pipeline::Result`, `Eval::AggregatedReport`, `Eval::BaselineDiff`, `Eval::PromptDiffComparator`, `Eval::EvalHistory`, `Eval::RetryOptimizer`, `OptimizeRakeTask`. Replaced the outdated `Eval::TraitEvaluator` entry with `Eval::ExpectationEvaluator`.
+- **Business framing added to guides** — every guide opens with a concrete production scenario or "why it matters" hook before the API reference.
+
+### Examples — consolidated on `SummarizeArticle`, renumbered 00-06
+
+The previous 12-file set mixed a private Reddit promo planner, customer support, meetings, keyword extraction, and translation. The new set is seven runnable files, each answering one adopter question on the README's `SummarizeArticle` case.
+
+| # | File | Answers |
+|---|------|---------|
+| 00 | `00_basics.rb` | How do I start? (seven incremental layers + real-LLM pointer) |
+| 01 | `01_fallback_showcase.rb` | Show me the gem in 30 seconds (zero API keys) |
+| 02 | `02_real_llm_minimal.rb` | How do I plug in a real LLM? (~30 lines) |
+| 03 | `03_summarize_with_keywords.rb` | How does the contract evolve? (growing prompt) |
+| 04 | `04_summarize_and_translate.rb` | Pipeline composition + pipeline-level `run_eval` |
+| 05 | `05_eval_dataset.rb` | How do I stop silent prompt regressions? |
+| 06 | `06_retry_variants.rb` | `attempts: 3`, `reasoning_effort` escalation, cross-provider (Ollama → Anthropic → OpenAI) |
+
+Every file carries an "Expected output" block in its header so readers see the result without running the script. The `docs/ideas/` directory is now fully untracked (already in `.gitignore`; one stray file removed from version control).
+
+### Examples — bug fixes carried along
+
+- **Schema pitfall fixed in 5 files** — `array :x do; string :y; ...; end` silently produces `items: string` and drops every declaration after the first, matching the documented pitfall in `spec/ruby_llm/contract/nested_schema_spec.rb:71`. Every affected array block is now wrapped in `object do...end`.
+- **`examples/09_eval_dataset.rb` `result[:passed]` → `result.passed?`** — the previous code called `[]` on an `Eval::CaseResult` and raised `NoMethodError` at runtime.
+
+### Testing
+
+- **New `spec/integration/pipeline_eval_spec.rb`** — three cases guaranteeing pipeline-level `run_eval` stays functional: happy path, final-step mismatch, and fail-fast propagation when an intermediate `validate` rejects. Closes the "09 STEP 5 pipeline evaluation" known issue flagged in the 0.7.2 release. The fail-fast case asserts `step_status == :validation_failed` and the validate's label in `details`, so a regression that short-circuits on schema instead of validate would fail loudly.
+
+### Deleted (private-project cleanup)
+
+- `examples/01_classify_threads.rb`, `02_generate_comment.rb`, `03_target_audience.rb`, `10_reddit_full_showcase.rb`, `spec/integration/reddit_pipeline_spec.rb` — Reddit Promo Planner was a separate private project; its examples do not belong in the gem's public repo.
+- `examples/02_output_schema.rb` — fully covered by `docs/guide/output_schema.md`; deleting avoids duplication.
+
 ## 0.7.2 (2026-04-22)
 
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby_llm-contract (0.7.2)
+    ruby_llm-contract (0.7.3)
       dry-types (~> 1.7)
       ruby_llm (~> 1.0)
       ruby_llm-schema (~> 0.3)
@@ -258,7 +258,7 @@ CHECKSUMS
   rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   ruby_llm (1.14.0) sha256=57c6f7034fc4a44504ea137d70f853b07824f1c1cdbe774ab3ab3522e7098deb
-  ruby_llm-contract (0.7.2)
+  ruby_llm-contract (0.7.3)
   ruby_llm-schema (0.3.0) sha256=a591edc5ca1b7f0304f0e2261de61ba4b3bea17be09f5cf7558153adfda3dec6
   ruby_parser (3.22.0) sha256=1eb4937cd9eb220aa2d194e352a24dba90aef00751e24c8dfffdb14000f15d23
   rubycritic (4.12.0) sha256=024fed90fe656fa939f6ea80aab17569699ac3863d0b52fd72cb99892247abc8

--- a/lib/ruby_llm/contract/version.rb
+++ b/lib/ruby_llm/contract/version.rb
@@ -2,6 +2,6 @@
 
 module RubyLLM
   module Contract
-    VERSION = "0.7.2"
+    VERSION = "0.7.3"
   end
 end


### PR DESCRIPTION
Adoption-friction release. **No gem-level code changes** — every delta is in `docs/`, `examples/`, or `spec/integration/`. Upgrading from 0.7.2 picks up the expanded guide set, the consolidated runnable showcases, and one extra integration spec.

## What landed in 0.7.3

Seven merged PRs (#21 through #27) collapsed into one release:

| PR | Theme |
|----|-------|
| #21 | Guide rewrite + adoption friction (why.md, "Do I need this?", outcome labels, TL;DR boxes) |
| #22 | Runnable aha-moment showcase (`01_fallback_showcase.rb`) + retry variants (`06_retry_variants.rb`) |
| #23 | `architecture.md` refresh + `docs/ideas/` untracked + Part A expected output |
| #24 | Schema pitfall fix (5 example files) + Expected output coverage |
| #25 | Examples consolidation — drop Reddit, renumber 00-06, restore pipeline + real-LLM minimal |
| #26 | Rails integration FAQ guide (pre-emptive adoption answers) |
| #27 | Pipeline-level `run_eval` coverage — closes the "09 STEP 5" known issue from 0.7.2 |

## Verification

- 1287 specs pass (was 1284 + 3 new from PR #27).
- 6/6 test-adapter examples run clean (`02_real_llm_minimal.rb` expectedly requires an API key).
- `bundle install` resolves `ruby_llm-contract 0.7.3`.

## Release checklist

- [x] `lib/ruby_llm/contract/version.rb` bumped to `0.7.3`
- [x] `CHANGELOG.md` entry with full details
- [x] `Gemfile.lock` regenerated
- [x] All guides and examples referenced exist and run

After merge:

- Tag `v0.7.3` on `main`
- `gem build ruby_llm-contract.gemspec`
- `gem push ruby_llm-contract-0.7.3.gem`
