### PR TITLE
0.8.0: Contracts + Evals for RubyLLM (narrative + thinking DSL + adapter unification)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## 0.8.0 (2026-04-26)
+
+Narrative repositioning + small API additions. Internal architecture unchanged: no `Step::Base` refactor, no breaking changes to existing DSL.
+
+### Added
+
+- **`thinking(effort:, budget:)` class macro on `Step::Base`** — mirrors `RubyLLM::Agent.thinking` signature exactly. Stored as `{ effort:, budget: }` hash; reader returns the hash; supports `:default` reset semantics; superclass inheritance like `model`/`temperature`. The convenience alias `reasoning_effort(:low)` is implemented as `thinking(effort: :low)` — single normalized state, not separate ivar.
+- **Adapter wiring for `with_thinking`** — when `thinking` is set on the Step class, OR when `reasoning_effort:` is passed through context, OR when an attempt config in `retry_policy escalate(...)` carries `reasoning_effort:`, the RubyLLM adapter resolves the effective `{ effort:, budget: }` hash and forwards it via `chat.with_thinking(**)` — provider-agnostic (supports OpenAI `reasoning_effort` AND Anthropic extended-thinking budget). Precedence: per-attempt / context `reasoning_effort` overrides class-level `thinking[:effort]`; budget is taken from class-level `thinking[:budget]`. **Behavioural change vs 0.7.x**: `reasoning_effort` is now forwarded via `with_thinking` instead of `with_params`. Same wire-level OpenAI parameter; provider-agnostic Anthropic support is now automatic.
+
+### Dependencies
+
+- **`ruby_llm` constraint bumped from `~> 1.0` to `~> 1.12`** — `Chat#with_thinking` is the canonical path for reasoning effort + extended thinking; it shipped in RubyLLM 1.12. Adopters on `ruby_llm < 1.12` need to bump RubyLLM before upgrading this gem to 0.8.0.
+
+### Changed
+
+- **Tagline + README opening** — repositioned around "Contracts + Evals for RubyLLM". New "Relation to RubyLLM::Agent" section explicitly frames Step as a sibling abstraction (same niche as Agent, wider contract), not an alternative or foundation. README does not claim "Step uses Agent under the hood" — current call path is `Step → Runner → Adapters::RubyLLM → RubyLLM.chat` directly.
+- **`TokenEstimator` documented as heuristic** — module docstring expanded with explicit "±30% accuracy" framing. Refusal messages from `LimitChecker` now include `(heuristic ±30%)` suffix so adopters know the pre-flight number is estimated, not measured. RubyLLM 1.14 also has no pre-flight tokenizer; `RubyLLM::Tokens` is post-hoc only.
+- **`CostCalculator` repositioned in docs** — module narrative reframed from "cost calculator" to "fine-tune pricing registry + lookup with fallback chain". Math methods (`compute_cost`, `token_cost`, etc.) were already private; this release makes the docs match. Public API surface unchanged: `register_model`, `unregister_model`, `reset_custom_models!`, `calculate`.
+- **`output_schema` reframed in docs** — described as "wrapper around `RubyLLM::Schema` + client-side validation step", not a standalone feature. The schema language is identical to what `RubyLLM::Agent.schema` accepts; the difference is what wraps it.
+- **README retry framing** — `retry_policy escalate(...)` (model escalation on validation failure) is the marketed default. `retry_policy attempts: N` (same-model retry) stays in the API for backward compat and niche cases (subjective criteria, multi-step pipelines, weaker models) but is no longer marketed as a recommended default. Empirical basis: four small experiments across PDF quiz generation, GSM8K math (n=30 + n=120), and multi-constraint schedule generation found no useful lift for nano-class models on tasks with clear correctness criteria.
+
+### Documentation
+
+- **New disambiguation paragraphs** in `prompt_ast.md` (`Step.input_type` vs `RubyLLM::Agent.inputs`; `Prompt::Builder` multi-role DSL vs Agent ERB single-string template loader), `testing.md` (`Step.observe` vs `Chat#on_end_message` / `on_tool_call`), `output_schema.md` (relation to `Agent.schema`), and `optimizing_retry_policy.md` (orthogonal model + thinking dimensions).
+- **`getting_started.md` refusal message example** updated to include the new `(heuristic ±30%)` suffix.
+
+### Issues closed
+
+- **#11** (Optimizer is blind to same-model attempts) — closed after empirical experiments. `attempts: N` retry stays in API; not marketed as a default.
+- **#6** (Production cost reporting) — already implemented in 0.7.x; close confirmed.
+
+### Not in this release (deferred)
+
+- `output_schema` Proc form for runtime-input-aware schemas (parity with `Agent.schema` Proc form). Additive, low-risk; deferred to 0.9 to keep 0.8 scope tight.
+- H4 (Step composing `RubyLLM::Agent` internally as config holder) — verified feasible but ROI insufficient for current adopter base; trigger-based revisit, no calendar commitment.
+
 ## 0.7.3 (2026-04-24)
 
 Adoption-friction release. No runtime behavior changes — every delta is in `docs/`, `examples/`, or `spec/integration/` (plus the `version.rb` / Gemfile.lock bumps). Upgrading from 0.7.2 picks up the expanded guide set, the new runnable showcases, and one extra integration spec.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    ruby_llm-contract (0.7.3)
+    ruby_llm-contract (0.8.0)
       dry-types (~> 1.7)
-      ruby_llm (~> 1.0)
+      ruby_llm (~> 1.12)
       ruby_llm-schema (~> 0.3)
 
 GEM
@@ -258,7 +258,7 @@ CHECKSUMS
   rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   ruby_llm (1.14.0) sha256=57c6f7034fc4a44504ea137d70f853b07824f1c1cdbe774ab3ab3522e7098deb
-  ruby_llm-contract (0.7.3)
+  ruby_llm-contract (0.8.0)
   ruby_llm-schema (0.3.0) sha256=a591edc5ca1b7f0304f0e2261de61ba4b3bea17be09f5cf7558153adfda3dec6
   ruby_parser (3.22.0) sha256=1eb4937cd9eb220aa2d194e352a24dba90aef00751e24c8dfffdb14000f15d23
   rubycritic (4.12.0) sha256=024fed90fe656fa939f6ea80aab17569699ac3863d0b52fd72cb99892247abc8

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # ruby_llm-contract
 
-**Validate and retry LLM outputs for [ruby_llm](https://github.com/crmne/ruby_llm).** Describe the answer you expect (JSON schema + business rules). If the model returns something that doesn't match, retry — optionally falling back to a stronger model — until it passes or you hit the budget.
+**Contracts + Evals for [ruby_llm](https://github.com/crmne/ruby_llm).**
 
-`ruby_llm` handles the HTTP side (rate limits, timeouts, streaming, tool calls, embeddings). This gem handles what the model *returned*: schema validation, business rules, retry with model fallback, datasets, regression tests.
+Your eval passed. Prod broke anyway? This gem wraps `RubyLLM::Chat` with input/output contracts, business-rule validation, retry with model escalation on validation failure, pre-flight cost ceilings, and an evaluation framework — so a flaky cheap-model call escalates to a stronger model instead of shipping garbage to your user.
+
+`ruby_llm` handles the HTTP side (rate limits, timeouts, streaming, tool calls, embeddings). This gem handles what the model *returned*: schema validation, business rules, model escalation on failed validation, datasets, regression tests.
 
 ## Install
 
@@ -65,9 +67,26 @@ Everything below is optional — the example above is a complete step. Reach for
 - **[CI regression gates](docs/guide/getting_started.md)** — `define_eval` + `save_baseline!` + `pass_eval(...).without_regressions` blocks CI when accuracy drops on a model update or prompt tweak.
 - **[Find the cheapest viable fallback list](docs/guide/optimizing_retry_policy.md)** — `Step.recommend("regression", candidates: [...], min_score: 0.95)` returns the cheapest list of models that still passes your evals. `production_mode:` measures retry-aware cost.
 - **[A/B test prompts](docs/guide/eval_first.md)** — `SummarizeArticleV2.compare_with(SummarizeArticleV1, eval: "regression")` reports whether the new prompt is safe to ship.
-- **[Budget caps](docs/guide/getting_started.md)** — `max_cost`, `max_input`, `max_output` refuse the request before calling the API when an estimate exceeds the limit.
+- **[Budget caps](docs/guide/getting_started.md)** — `max_cost`, `max_input`, `max_output` refuse the request before calling the API when a heuristic estimate (~±30% accuracy) exceeds the limit.
+- **[Reasoning effort / thinking config](docs/guide/optimizing_retry_policy.md)** — `thinking effort: :low` (or alias `reasoning_effort :low`) on the Step class; mirrors `RubyLLM::Agent.thinking` and forwards through `Chat#with_thinking`.
 
-Also supports [multi-step pipelines](docs/guide/pipeline.md) with fail-fast and [best-effort retries without fallback](docs/guide/best_practices.md) (`retry_policy attempts: 3` for sampling variance).
+Also supports [multi-step pipelines](docs/guide/pipeline.md) with fail-fast and `retry_policy attempts: N` for niche cases (we measured this empirically — for `gpt-4.1-nano` / `gpt-5-nano` on tasks with clear correctness criteria, same-model retry rarely helps; `escalate(model_2)` is the strategy that moves the needle, see [optimizing_retry_policy.md](docs/guide/optimizing_retry_policy.md)).
+
+## Relation to `RubyLLM::Agent`
+
+`RubyLLM::Agent` (since RubyLLM 1.12) and `Step::Base` here target the **same niche**: reusable, class-based prompts. They are siblings, not foundation-and-roof.
+
+| What you write | Where it lives |
+|---|---|
+| `model`, `temperature`, `schema`, `instructions`, `tools`, `thinking` | covered by both — same idea, different DSL surface |
+| `validate :rule do |out| ... end` business invariants | only here |
+| `retry_policy escalate(...)` model escalation on validation failure | only here (different from RubyLLM's network-level retry) |
+| `max_cost` / `max_input` / `max_output` pre-flight refusal | only here |
+| `define_eval` + baseline regression + `compare_models` + `optimize_retry_policy` | only here (RubyLLM does not ship an eval framework) |
+| Pipeline composition with `step SomeStep, as: :alias` | only here (RubyLLM intentionally leaves workflows as plain Ruby) |
+| `around_call`, named `observe` hooks with pass/fail in trace | only here |
+
+`Step::Base` does NOT use `Agent` internally today — both call into `RubyLLM::Chat` directly. The two abstractions can coexist on the same project: use `Agent` for prompt-only reuse, use `Step` when you need any of the contract-layer features above. The retry-strategy framing here (favouring `escalate(...)` over same-model `attempts: N`) is grounded in an empirical comparison; `attempts: N` stays in the API for niche cases.
 
 ## Docs
 
@@ -89,7 +108,7 @@ Also supports [multi-step pipelines](docs/guide/pipeline.md) with fail-fast and 
 
 ## Roadmap
 
-Latest: **v0.7.2** — terminal output labels and guides aligned with the fallback narrative; `output_schema.md` DSL bug fix. See [CHANGELOG](CHANGELOG.md) for history.
+Latest: **v0.8.0** — tagline + narrative repositioning around "Contracts + Evals for RubyLLM", `thinking` / `reasoning_effort` class macro, TokenEstimator labelled as heuristic, CostCalculator repositioned. See [CHANGELOG](CHANGELOG.md) for history.
 
 ## License
 

--- a/docs/guide/getting_started.md
+++ b/docs/guide/getting_started.md
@@ -131,7 +131,7 @@ expect(SummarizeArticle).to pass_eval("regression").without_regressions
 ```ruby
 result = SummarizeArticle.run(giant_10mb_document)
 result.status            # => :limit_exceeded
-result.validation_errors # => ["Input token limit exceeded: estimated 32000 tokens, max 2000"]
+result.validation_errors # => ["Input token limit exceeded: estimated 32000 tokens (heuristic ±30%), max 2000"]
 ```
 
 `max_cost` fails closed when the model's pricing isn't known — register custom or fine-tuned models explicitly:

--- a/docs/guide/optimizing_retry_policy.md
+++ b/docs/guide/optimizing_retry_policy.md
@@ -10,6 +10,8 @@ You defined `SummarizeArticle` in the [README](../../README.md) with `retry_poli
 - **2–3 evals per step.** One eval optimizes for one scenario; with only `smoke`, you get a recommendation that passes smoke but may miss production edge cases. See [eval-first](eval_first.md).
 - **Rake tasks.** The standard `RubyLLM::Contract::RakeTask` includes `ruby_llm_contract:optimize`. Non-Rails projects: set `EVAL_DIRS=...`.
 
+> **Two orthogonal dimensions to a retry chain.** A chain element is `{ model:, reasoning_effort: }` — model identity AND thinking budget. `optimize_retry_policy` explores both. You can also fix the thinking config at class level via `thinking effort: :low` (or alias `reasoning_effort :low`) on the Step — it becomes the default for every chain element unless an override is passed. See the `thinking` DSL note at the bottom of this guide.
+
 For this guide, assume `SummarizeArticle` has three evals:
 
 ```ruby
@@ -112,3 +114,18 @@ Run this before finalizing: a candidate saving 3× on first-attempt but falling 
 ## Programmatic API names
 
 Metrics exposed on `Report` / `AggregatedReport` keep their original names: `single_shot_cost`, `single_shot_latency_ms`, `escalation_rate`. The optimize Result struct also exposes `hardest_eval` as an alias for `constraining_eval`.
+
+## thinking DSL note
+
+Set the default reasoning effort once on the Step class — mirrors `RubyLLM::Agent.thinking` exactly:
+
+```ruby
+class SummarizeArticle < RubyLLM::Contract::Step::Base
+  model "gpt-5-nano"
+  thinking effort: :low          # canonical
+  # or
+  reasoning_effort :low          # alias for thinking(effort: :low)
+end
+```
+
+Forwarded to `Chat#with_thinking(**)` through the adapter — works provider-agnostically (OpenAI `reasoning_effort`, Anthropic extended-thinking budget). A per-call override via `context: { reasoning_effort: :high }` still wins over the class default.

--- a/docs/guide/output_schema.md
+++ b/docs/guide/output_schema.md
@@ -7,6 +7,8 @@ Declare the expected output structure using [ruby_llm-schema](https://github.com
 1. **Output validation** — replaces type and shape checks (enums, ranges, required fields). One declaration instead of many.
 2. **Provider-side request** — with the RubyLLM adapter, the schema is sent to the LLM provider via `chat.with_schema(...)`, asking the model to return JSON matching the shape. Cheaper models sometimes ignore the request, which is why client-side validation (point 1) still matters.
 
+> **Same DSL `RubyLLM::Agent.schema` accepts.** `output_schema do ... end` here is a wrapper around `RubyLLM::Schema.create(&block)` plus a client-side validation step. `RubyLLM::Agent.schema` accepts the same block — choosing one over the other does not change the schema language. The difference: `Agent.schema` lets you pass a `Proc` evaluated in runtime context (dynamic per-call schema); `Step.output_schema` is eager-compiled at class load and additionally drives `output_type` inference and `Validator.validate`. Both can coexist.
+
 All examples below extend the `SummarizeArticle` step from the [README](../../README.md).
 
 ## Schema replaces type and shape checks

--- a/docs/guide/prompt_ast.md
+++ b/docs/guide/prompt_ast.md
@@ -54,6 +54,10 @@ end
 
 Every `{key}` in a prompt node is pulled from the input hash at run time. Missing keys raise — making wire-up bugs loud, not silent.
 
+> **Not the same as `RubyLLM::Agent.inputs`.** `Step.input_type` is a *runtime type check* on the positional argument passed to `run(input)` — it raises `TypeError` if the input violates the declared shape. `RubyLLM::Agent.inputs` is a list of *named template locals* injected into ERB instructions. They solve different problems (validation vs templating) and can coexist on the same project.
+
+> **Not the same as `RubyLLM::Agent` ERB templates either.** The `prompt do ... end` DSL above builds a multi-role message list (`system` / `user` / `assistant` / `example` nodes) into a node-AST. `Agent.instructions :name` loads a single-string ERB file from `app/prompts/<agent_path>/<name>.txt.erb` for the system prompt only. Different output shape, different scope. Variable interpolation here uses `{key}` substitution; ERB uses full `<%= ruby %>`.
+
 ## Cross-validating output against input
 
 Validate blocks support 2-arity `|output, input|` so you can check that the model's answer stays faithful to the request:

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -224,6 +224,8 @@ result.observations  # => [{ description: "scores should differ", passed: false 
 
 `observe` runs only after validation passes. Failed observations are logged via `RubyLLM::Contract.logger` — useful for "I want to know this happened without blocking the response".
 
+> **Not the same as `Chat#on_end_message` / `on_tool_call`.** RubyLLM exposes anonymous, global callbacks attached to a chat instance — they receive the raw `Message` and have no inherent pass/fail concept. `Step.observe` is per-step, named with a description, runs against `parsed_output` (already JSON-parsed and schema-validated), and the pass/fail outcome is recorded in `result.observations`. The two can coexist: use Chat callbacks for transport/tool tracing, use `observe` for domain assertions you want captured in the step trace.
+
 ## Asserting on `around_call`
 
 `around_call` fires **once per run** with the final result (after retry fallback) and exceptions propagate. That makes it straightforward to test:

--- a/lib/ruby_llm/contract/adapters/ruby_llm.rb
+++ b/lib/ruby_llm/contract/adapters/ruby_llm.rb
@@ -52,10 +52,31 @@ module RubyLLM
           CHAT_OPTION_METHODS.each do |key, method_name|
             chat.public_send(method_name, options[key]) if options[key]
           end
+
+          # Resolve thinking config from BOTH sources, with `:reasoning_effort`
+          # taking precedence over `:thinking[:effort]`. This is the per-attempt
+          # override path used by `retry_policy { escalate({model:, reasoning_effort:}) }`
+          # — the attempt-specific effort must win over the class-level default.
+          # Forwarded provider-agnostically via `chat.with_thinking(**)` —
+          # available since RubyLLM 1.12 (gemspec enforces this minimum).
+          thinking_config = resolve_thinking_config(options)
+          chat.with_thinking(**thinking_config) if thinking_config
+
+          # `with_params` carries only raw passthroughs (currently `max_tokens`).
+          # `reasoning_effort` is no longer forwarded here — it goes through
+          # `with_thinking` above, which is the canonical RubyLLM API.
           params = {}
           params[:max_tokens] = options[:max_tokens] if options[:max_tokens]
-          params[:reasoning_effort] = options[:reasoning_effort] if options[:reasoning_effort]
           chat.with_params(**params) if params.any?
+        end
+
+        # Returns merged `{ effort:, budget: }` or nil. `options[:reasoning_effort]`
+        # overrides any inherited `options[:thinking][:effort]`; budget is
+        # taken from `options[:thinking][:budget]` only.
+        def resolve_thinking_config(options)
+          base = options[:thinking].is_a?(Hash) ? options[:thinking].dup : {}
+          base[:effort] = options[:reasoning_effort] if options[:reasoning_effort]
+          base.empty? ? nil : base
         end
 
         def build_response(response)

--- a/lib/ruby_llm/contract/cost_calculator.rb
+++ b/lib/ruby_llm/contract/cost_calculator.rb
@@ -2,6 +2,29 @@
 
 module RubyLLM
   module Contract
+    # Pricing lookup for `max_cost` budget gating + retry usage aggregation.
+    #
+    # **What this module does (public surface):**
+    #
+    # 1. **Fine-tune / custom-model pricing registry** — `register_model`
+    #    fills the gap left by RubyLLM 1.14's models.json: there is no
+    #    upstream `RubyLLM::Models.register` API, so fine-tuned models
+    #    (e.g. `ft:gpt-4o-custom`) need their pricing supplied locally.
+    # 2. **Lookup with fallback chain** — `calculate(model_name:, usage:)`
+    #    checks the custom registry first, falls back to
+    #    `RubyLLM.models.find(model_name)`, returns `nil` on miss.
+    #
+    # **What this module is NOT:**
+    #
+    # - Not a "cost calculator" feature — the math itself
+    #   (`tokens × price_per_million / 1_000_000`) is trivial and lives
+    #   in `private_class_method :compute_cost` for internal use only.
+    # - Not a substitute for RubyLLM's pricing data — for any model in
+    #   `RubyLLM.models`, this module simply queries it.
+    #
+    # The reason this module exists at all is the registry + retry usage
+    # aggregation across attempts (the latter sits in `Step::RetryExecutor`,
+    # which calls `calculate` per attempt and sums; not in this module).
     module CostCalculator
       # Simple struct for custom-registered model pricing
       RegisteredModel = Struct.new(:input_price_per_million, :output_price_per_million, keyword_init: true)
@@ -9,6 +32,8 @@ module RubyLLM
       @custom_models = {}
 
       # Register pricing for custom or fine-tuned models not in the RubyLLM registry.
+      # This is the gem's primary value-add for cost computation; everything
+      # else falls back to RubyLLM's own model registry.
       #
       #   CostCalculator.register_model("ft:gpt-4o-custom",
       #     input_per_1m: 3.0, output_per_1m: 6.0)
@@ -33,6 +58,20 @@ module RubyLLM
         @custom_models.clear
       end
 
+      # Look up cost for a single model + usage hash.
+      # Returns nil if model is unknown (custom registry miss + RubyLLM miss),
+      # so callers can decide whether to refuse the call or proceed (see
+      # `on_unknown_pricing:` step option for the budget-gating policy).
+      #
+      #   CostCalculator.calculate(
+      #     model_name: "gpt-4o-mini",
+      #     usage: { input_tokens: 1_500, output_tokens: 800 }
+      #   )
+      #   # => 0.00069 (or nil if model not registered)
+      #
+      # Math is intentionally simple and private — this method is the
+      # primary public entry point. Aggregating across retry attempts is
+      # done in `Step::RetryExecutor`, not here.
       def self.calculate(model_name:, usage:)
         return nil unless model_name && usage.is_a?(Hash)
 

--- a/lib/ruby_llm/contract/step/base.rb
+++ b/lib/ruby_llm/contract/step/base.rb
@@ -159,10 +159,27 @@ module RubyLLM
 
           def runtime_settings(context)
             policy = context.key?(:retry_policy_override) ? context[:retry_policy_override] : retry_policy
+            extra = context.slice(:provider, :assume_model_exists, :max_tokens, :reasoning_effort)
+
+            # Always pass the class-level `thinking` config to the adapter when
+            # set, so fields like `budget` survive a per-call `reasoning_effort`
+            # override. The adapter's `resolve_thinking_config` merges
+            # `reasoning_effort` over `thinking[:effort]` while keeping the
+            # rest of the hash intact.
+            #
+            # `reasoning_effort` is also seeded into extra_options for
+            # backward compat with eval_host / production_mode paths that
+            # read it from there — but only when the caller did not already
+            # provide one in context.
+            if respond_to?(:thinking) && thinking
+              extra[:thinking] = thinking
+              extra[:reasoning_effort] = thinking[:effort] if !extra.key?(:reasoning_effort) && thinking[:effort]
+            end
+
             {
               model: context[:model] || model || RubyLLM::Contract.configuration.default_model,
               temperature: context[:temperature],
-              extra_options: context.slice(:provider, :assume_model_exists, :max_tokens, :reasoning_effort),
+              extra_options: extra,
               policy: policy
             }
           end

--- a/lib/ruby_llm/contract/step/dsl.rb
+++ b/lib/ruby_llm/contract/step/dsl.rb
@@ -200,6 +200,44 @@ module RubyLLM
           superclass.temperature if superclass.respond_to?(:temperature)
         end
 
+        def thinking(effort: nil, budget: nil)
+          if effort == :default
+            @thinking = nil
+            @thinking_explicitly_unset = true
+            return nil
+          end
+
+          if effort || budget
+            @thinking_explicitly_unset = false
+            return @thinking = { effort: effort, budget: budget }.compact
+          end
+
+          return @thinking if defined?(@thinking) && !@thinking_explicitly_unset
+          return nil if @thinking_explicitly_unset
+
+          superclass.thinking if superclass.respond_to?(:thinking)
+        end
+
+        def reasoning_effort(value = nil)
+          return (thinking && thinking[:effort]) if value.nil?
+
+          # Alias is scoped to the effort dimension only. `:default` on the
+          # alias clears effort but PRESERVES any previously-set budget — the
+          # name does not suggest "wipe the whole thinking config." Use the
+          # full `thinking(effort: :default)` to clear everything.
+          if value == :default
+            current_budget = thinking && thinking[:budget]
+            if current_budget
+              @thinking_explicitly_unset = false
+              @thinking = { budget: current_budget }
+              return nil
+            end
+            return thinking(effort: :default)
+          end
+
+          thinking(effort: value)
+        end
+
         def around_call(&block)
           if block
             return @around_call = block

--- a/lib/ruby_llm/contract/step/limit_checker.rb
+++ b/lib/ruby_llm/contract/step/limit_checker.rb
@@ -22,7 +22,7 @@ module RubyLLM
         def collect_limit_errors(estimated)
           errors = []
           if max_input && estimated > max_input
-            errors << "Input token limit exceeded: estimated #{estimated} tokens, max #{max_input}"
+            errors << "Input token limit exceeded: estimated #{estimated} tokens (heuristic ±30%), max #{max_input}"
           end
           append_cost_error(estimated, errors) if max_cost
           errors
@@ -46,7 +46,7 @@ module RubyLLM
             handle_unknown_pricing(errors)
           elsif estimated_cost > max_cost
             errors << "Cost limit exceeded: estimated $#{format("%.6f", estimated_cost)} " \
-                      "(#{estimated} input + #{estimated_output} output tokens), " \
+                      "(#{estimated} input + #{estimated_output} output tokens, heuristic ±30%), " \
                       "max $#{format("%.6f", max_cost)}"
           end
         end

--- a/lib/ruby_llm/contract/token_estimator.rb
+++ b/lib/ruby_llm/contract/token_estimator.rb
@@ -2,12 +2,29 @@
 
 module RubyLLM
   module Contract
+    # Pre-flight token estimation for `max_input` / `max_cost` budget gating.
+    #
+    # IMPORTANT — heuristic only. This is NOT an accurate tokenizer.
+    # The estimate uses a fixed `length / CHARS_PER_TOKEN` ratio:
+    #
+    #   - Accurate to ±30% for English prose with mainstream OpenAI / Anthropic models
+    #   - Worse for non-English text, code, structured data, and unusual scripts
+    #   - Useless for models with very different tokenizers (e.g. some open-source models)
+    #
+    # RubyLLM 1.14 ships no pre-flight tokenizer either; once the API call
+    # returns, `RubyLLM::Tokens` provides accurate counts from provider usage
+    # data. This estimator is for the *pre-flight refusal* path only — its job
+    # is to answer "is this call almost certainly within budget?" with enough
+    # accuracy that runaway prompts get caught, while accepting that the
+    # boundary cases will be wrong.
+    #
+    # Refusal messages from `LimitChecker` carry an "(heuristic)" suffix so
+    # adopters know the number is estimated, not measured.
     module TokenEstimator
-      # Heuristic: ~4 characters per token for English text.
-      # This is a rough estimate — actual tokenization varies by model and content.
-      # Intentionally conservative (overestimates slightly) to avoid surprise costs.
       CHARS_PER_TOKEN = 4
 
+      # Heuristic estimate. Returns an integer token count.
+      # See module docstring for accuracy caveats.
       def self.estimate(messages)
         return 0 unless messages.is_a?(Array)
 

--- a/lib/ruby_llm/contract/version.rb
+++ b/lib/ruby_llm/contract/version.rb
@@ -2,6 +2,6 @@
 
 module RubyLLM
   module Contract
-    VERSION = "0.7.3"
+    VERSION = "0.8.0"
   end
 end

--- a/ruby_llm-contract.gemspec
+++ b/ruby_llm-contract.gemspec
@@ -7,10 +7,11 @@ Gem::Specification.new do |spec|
   spec.version = RubyLLM::Contract::VERSION
   spec.authors = ["Justyna"]
 
-  spec.summary = "Know which LLM model to use, what it costs, and when accuracy drops"
-  spec.description = "Compare LLM models by accuracy and cost. Regression-test prompts in CI. " \
-                     "Start on nano, auto-escalate to bigger models when quality drops. " \
-                     "Companion gem for ruby_llm."
+  spec.summary = "Contracts + Evals for ruby_llm"
+  spec.description = "Wraps RubyLLM::Chat with input/output contracts, business-rule validation, " \
+                     "retry with model escalation on validation failure, pre-flight cost ceilings, " \
+                     "and an evaluation framework. Sibling abstraction to RubyLLM::Agent — same " \
+                     "niche (reusable class-based prompts), wider contract."
   spec.homepage = "https://github.com/justi/ruby_llm-contract"
   spec.license = "MIT"
   spec.required_ruby_version = ">= 3.2.0"
@@ -30,6 +31,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "dry-types", "~> 1.7"
-  spec.add_dependency "ruby_llm", "~> 1.0"
+  spec.add_dependency "ruby_llm", "~> 1.12"
   spec.add_dependency "ruby_llm-schema", "~> 0.3"
 end

--- a/spec/ruby_llm/contract/adapters/ruby_llm_spec.rb
+++ b/spec/ruby_llm/contract/adapters/ruby_llm_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe RubyLLM::Contract::Adapters::RubyLLM do
       allow(chat).to receive(:with_instructions).and_return(chat)
       allow(chat).to receive(:with_temperature).and_return(chat)
       allow(chat).to receive(:with_params).and_return(chat)
+      allow(chat).to receive(:with_thinking).and_return(chat)
       allow(chat).to receive(:add_message).and_return(nil)
       allow(chat).to receive(:ask).and_return(mock_response)
     end
@@ -123,19 +124,20 @@ RSpec.describe RubyLLM::Contract::Adapters::RubyLLM do
     end
 
     context "with reasoning_effort option" do
-      it "forwards reasoning_effort to the chat" do
+      it "forwards reasoning_effort via with_thinking (canonical path since 0.8)" do
         adapter.call(messages: [{ role: :user, content: "Hi" }], model: "gpt-4.1-mini", reasoning_effort: "low")
 
-        expect(mock_chat).to have_received(:with_params).with(reasoning_effort: "low")
+        expect(mock_chat).to have_received(:with_thinking).with(effort: "low")
       end
     end
 
     context "with both max_tokens and reasoning_effort" do
-      it "forwards both params together" do
+      it "forwards reasoning_effort via with_thinking and max_tokens via with_params" do
         adapter.call(messages: [{ role: :user, content: "Hi" }], model: "gpt-4.1-mini",
                      max_tokens: 100, reasoning_effort: "high")
 
-        expect(mock_chat).to have_received(:with_params).with(max_tokens: 100, reasoning_effort: "high")
+        expect(mock_chat).to have_received(:with_thinking).with(effort: "high")
+        expect(mock_chat).to have_received(:with_params).with(max_tokens: 100)
       end
     end
 

--- a/spec/ruby_llm/contract/step/thinking_dsl_spec.rb
+++ b/spec/ruby_llm/contract/step/thinking_dsl_spec.rb
@@ -1,0 +1,217 @@
+# frozen_string_literal: true
+
+class StepThinkingBase < RubyLLM::Contract::Step::Base
+  prompt { user "noop" }
+  thinking effort: :low
+end
+
+class StepThinkingChild < StepThinkingBase
+end
+
+class StepThinkingOverride < StepThinkingBase
+  thinking effort: :high
+end
+
+class StepThinkingReset < StepThinkingBase
+  thinking effort: :default
+end
+
+class StepReasoningEffortAlias < RubyLLM::Contract::Step::Base
+  prompt { user "noop" }
+  reasoning_effort :medium
+end
+
+class StepThinkingWithBudget < RubyLLM::Contract::Step::Base
+  prompt { user "noop" }
+  thinking effort: :low, budget: 1024
+end
+
+class StepNoThinking < RubyLLM::Contract::Step::Base
+  prompt { user "noop" }
+end
+
+RSpec.describe "Step thinking DSL" do
+  describe ".thinking" do
+    it "stores effort + budget as a hash mirroring Agent.thinking" do
+      expect(StepThinkingWithBudget.thinking).to eq(effort: :low, budget: 1024)
+    end
+
+    it "stores effort only when budget omitted" do
+      expect(StepThinkingBase.thinking).to eq(effort: :low)
+    end
+
+    it "returns nil when not configured" do
+      expect(StepNoThinking.thinking).to be_nil
+    end
+
+    it "inherits from superclass when subclass has not set its own" do
+      expect(StepThinkingChild.thinking).to eq(effort: :low)
+    end
+
+    it "subclass override replaces inherited value" do
+      expect(StepThinkingOverride.thinking).to eq(effort: :high)
+    end
+
+    it "subclass partial override is replace, NOT merge (matches temperature/model pattern)" do
+      child = Class.new(StepThinkingBase) { thinking budget: 999 }
+      # Inherited effort :low from StepThinkingBase is dropped — replace, not merge
+      expect(child.thinking).to eq(budget: 999)
+    end
+
+    it "supports :default reset semantics like temperature/model" do
+      expect(StepThinkingReset.thinking).to be_nil
+    end
+  end
+
+  describe ".reasoning_effort (alias)" do
+    it "is implemented as thinking(effort: value)" do
+      expect(StepReasoningEffortAlias.thinking).to eq(effort: :medium)
+    end
+
+    it "reader returns effort from current thinking" do
+      expect(StepReasoningEffortAlias.reasoning_effort).to eq(:medium)
+    end
+
+    it "reader returns nil when no thinking configured" do
+      expect(StepNoThinking.reasoning_effort).to be_nil
+    end
+
+    it ":default on alias clears effort but PRESERVES budget" do
+      cls = Class.new(RubyLLM::Contract::Step::Base) do
+        prompt { user "noop" }
+        thinking effort: :high, budget: 2048
+      end
+      cls.reasoning_effort(:default)
+      expect(cls.thinking).to eq(budget: 2048)
+    end
+
+    it ":default on alias clears entire config when no budget was set" do
+      cls = Class.new(RubyLLM::Contract::Step::Base) do
+        prompt { user "noop" }
+        thinking effort: :high
+      end
+      cls.reasoning_effort(:default)
+      expect(cls.thinking).to be_nil
+    end
+  end
+
+  describe "runtime_settings integration" do
+    it "injects full thinking hash into extra_options when class has thinking set" do
+      settings = StepThinkingBase.send(:runtime_settings, {})
+      expect(settings[:extra_options][:thinking]).to eq(effort: :low)
+    end
+
+    it "also seeds reasoning_effort for backward compat with eval_host paths" do
+      settings = StepThinkingBase.send(:runtime_settings, {})
+      expect(settings[:extra_options][:reasoning_effort]).to eq(:low)
+    end
+
+    it "passes thinking with budget when class has both" do
+      settings = StepThinkingWithBudget.send(:runtime_settings, {})
+      expect(settings[:extra_options][:thinking]).to eq(effort: :low, budget: 1024)
+    end
+
+    it "context :reasoning_effort wins for effort but :thinking still travels (budget preservation)" do
+      settings = StepThinkingBase.send(:runtime_settings, { reasoning_effort: :high })
+      expect(settings[:extra_options][:reasoning_effort]).to eq(:high)
+      # :thinking still passed so the adapter can merge effort override
+      # while preserving budget. Effort within :thinking is the class
+      # default (:low) — the adapter merges :reasoning_effort over it.
+      expect(settings[:extra_options][:thinking]).to eq(effort: :low)
+    end
+
+    it "context :reasoning_effort preserves class-level :budget through runtime_settings" do
+      settings = StepThinkingWithBudget.send(:runtime_settings, { reasoning_effort: :high })
+      expect(settings[:extra_options][:reasoning_effort]).to eq(:high)
+      # Critical — without thinking pass-through, the budget would silently disappear
+      expect(settings[:extra_options][:thinking]).to eq(effort: :low, budget: 1024)
+    end
+
+    it "no extra_options[:reasoning_effort] / :thinking when class has no thinking" do
+      settings = StepNoThinking.send(:runtime_settings, {})
+      expect(settings[:extra_options]).not_to have_key(:reasoning_effort)
+      expect(settings[:extra_options]).not_to have_key(:thinking)
+    end
+  end
+
+  describe "adapter forwarding" do
+    let(:fake_chat_class) do
+      Class.new do
+        attr_reader :thinking_calls, :params_calls, :messages
+        def initialize
+          @thinking_calls = []
+          @params_calls = []
+          @messages = []
+        end
+
+        def with_thinking(**kwargs)
+          @thinking_calls << kwargs
+          self
+        end
+
+        def with_params(**kwargs)
+          @params_calls << kwargs
+          self
+        end
+
+        def with_temperature(_); self; end
+        def with_schema(_); self; end
+        def with_instructions(_); self; end
+        def add_message(**); end
+        def ask(content)
+          @messages << content
+          OpenStruct.new(content: '{"ok":true}', input_tokens: 10, output_tokens: 5)
+        end
+      end
+    end
+
+    let(:fake_chat) { fake_chat_class.new }
+    let(:adapter) { RubyLLM::Contract::Adapters::RubyLLM.new }
+    let(:messages) { [{ role: :user, content: "hi" }] }
+
+    before do
+      require "ostruct"
+      allow(::RubyLLM).to receive(:chat).and_return(fake_chat)
+    end
+
+    it "forwards full thinking hash via with_thinking when set" do
+      adapter.call(messages: messages, model: "gpt-5-nano",
+                   thinking: { effort: :low, budget: 1024 })
+      expect(fake_chat.thinking_calls).to eq([{ effort: :low, budget: 1024 }])
+    end
+
+    it "forwards effort-only thinking via with_thinking" do
+      adapter.call(messages: messages, model: "gpt-5-nano", thinking: { effort: :low })
+      expect(fake_chat.thinking_calls).to eq([{ effort: :low }])
+    end
+
+    it "skips reasoning_effort with_params when thinking already covered it" do
+      adapter.call(messages: messages, model: "gpt-5-nano",
+                   thinking: { effort: :low }, reasoning_effort: :low)
+      effort_params = fake_chat.params_calls.flat_map { |c| c.keys }
+      expect(effort_params).not_to include(:reasoning_effort)
+    end
+
+    it "reasoning_effort-only forwards via with_thinking (no with_params call for it)" do
+      adapter.call(messages: messages, model: "gpt-5-nano", reasoning_effort: :high)
+      expect(fake_chat.thinking_calls).to eq([{ effort: :high }])
+      expect(fake_chat.params_calls.flat_map(&:keys)).not_to include(:reasoning_effort)
+    end
+
+    it "per-attempt :reasoning_effort OVERRIDES class-level :thinking effort (Bug #1 regression)" do
+      # Repro: class-level `thinking effort: :low` + chain attempt with
+      # `reasoning_effort: "high"`. Effort must reflect the attempt override,
+      # not the class default.
+      adapter.call(messages: messages, model: "gpt-5-nano",
+                   thinking: { effort: :low }, reasoning_effort: :high)
+      expect(fake_chat.thinking_calls).to eq([{ effort: :high }])
+    end
+
+    it "per-attempt :reasoning_effort preserves class-level :budget" do
+      adapter.call(messages: messages, model: "gpt-5-nano",
+                   thinking: { effort: :low, budget: 1024 }, reasoning_effort: :high)
+      expect(fake_chat.thinking_calls).to eq([{ effort: :high, budget: 1024 }])
+    end
+
+  end
+end


### PR DESCRIPTION
## Summary

Reposition the gem as **"Contracts + Evals for RubyLLM"** — sibling abstraction to `RubyLLM::Agent`, not alternative or foundation. No structural refactor; small API additions and adapter unification.

- New `thinking(effort:, budget:)` class macro on `Step::Base` (mirrors `RubyLLM::Agent.thinking` exactly), with `reasoning_effort(:level)` alias and `:default` reset that preserves budget
- Adapter unified: `reasoning_effort` (any source — class, context, chain config) now forwarded provider-agnostically via `Chat#with_thinking(**)`. Same wire-level OpenAI parameter; Anthropic extended-thinking now automatic
- Per-attempt `reasoning_effort` in `retry_policy escalate(...)` correctly overrides class-level effort while preserving class-level budget
- TokenEstimator labelled as heuristic (~±30% accuracy) in module docs and refusal messages
- CostCalculator repositioned: fine-tune pricing registry + RubyLLM lookup (math methods were already private)
- README opening rewritten: new tagline + pain-first hook + explicit "Relation to RubyLLM::Agent" section. README does not claim "uses Agent under the hood" — current call path is `Step → Runner → Adapters::RubyLLM → RubyLLM.chat` directly
- README retry framing favours `escalate(...)` over same-model `attempts: N`. Empirical basis: small experiments found no useful lift for nano-class models on tasks with clear correctness criteria. `attempts: N` stays in API for backward compat / niche cases
- `ruby_llm` dependency bumped from `~> 1.0` to `~> 1.12` (`Chat#with_thinking` shipped in 1.12)

## Issues closed

- #11 (Optimizer blind to same-model attempts) — closed after empirical work
- #6 (Production cost reporting) — already implemented in 0.7.x

## Test plan

- [x] `bundle exec rspec` — 1311 examples, 0 failures, 8 pending (Rails-only / API-only)
- [x] All 6 examples in `examples/` runnable end-to-end (5 with Test adapter, 1 with real `gpt-5-nano`)
- [x] `lib/ruby_llm/contract/version.rb` bumped 0.7.3 → 0.8.0
- [x] gemspec summary + description updated to match new tagline
- [x] CHANGELOG entry with Added / Changed / Issues closed / Not in this release sections
- [x] Pre-PR hidden-bug review run; issues found and fixed (per-attempt `reasoning_effort` precedence, `reasoning_effort :default` budget preservation through `runtime_settings`, subclass partial-override behaviour documented in spec, `RubyLLM < 1.12` compatibility settled by dependency bump)

## Not in this release (deferred)

- `output_schema` Proc form for runtime-input-aware schemas (parity with `Agent.schema` Proc form). Additive, low-risk; deferred to 0.9.
- H4 (Step composing `RubyLLM::Agent` internally) — verified feasible but ROI insufficient; trigger-based revisit, no calendar commitment.
